### PR TITLE
fix: сохранять prerelease-версию в Android-пакете

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,7 +171,16 @@ jobs:
           path: .
 
       - name: Build Android ${{ matrix.out }} artifact
-        run: dart setup.dart android --out ${{ matrix.out }} ${{ env.IS_STABLE == 'true' && '--env stable' || '' }}
+        run: |
+          release_channel=pre
+          if [ "${{ env.IS_STABLE }}" = "true" ]; then
+            release_channel=stable
+          fi
+          version_name="${GITHUB_REF_NAME#v}"
+          dart setup.dart android \
+            --out ${{ matrix.out }} \
+            --env "$release_channel" \
+            --version-name "$version_name"
 
       - name: Upload Android ${{ matrix.out }} artifact
         uses: actions/upload-artifact@v6

--- a/setup.dart
+++ b/setup.dart
@@ -65,6 +65,7 @@ Future<void> main(List<String> args) async {
     stderr.writeln(
       'FlClashM is Android-only. Supported command: dart setup.dart android '
       '[--arch arm|arm64|amd64] [--env stable|pre] '
+      '[--version-name <version>] '
       '[--out app|core|runtime-assets|split-apk|universal-apk|appbundle]',
     );
     exitCode = 64;
@@ -95,6 +96,7 @@ Future<void> main(List<String> args) async {
     await _buildAndroidArtifacts(
       env: command.env,
       coreVersion: coreVersion,
+      versionName: command.versionName,
     );
     return;
   }
@@ -103,6 +105,7 @@ Future<void> main(List<String> args) async {
     out: command.out,
     env: command.env,
     coreVersion: coreVersion,
+    versionName: command.versionName,
   );
 }
 
@@ -114,6 +117,7 @@ CommandArgs _parseArgs(List<String> args) {
   var arch = '';
   var env = 'pre';
   var out = 'app';
+  String? versionName;
 
   for (var i = 1; i < args.length; i++) {
     final arg = args[i];
@@ -136,6 +140,12 @@ CommandArgs _parseArgs(List<String> args) {
         }
         out = args[++i];
         break;
+      case '--version-name':
+        if (i + 1 >= args.length) {
+          throw ArgumentError('Missing value for --version-name');
+        }
+        versionName = args[++i];
+        break;
       default:
         throw ArgumentError('Unknown argument: $arg');
     }
@@ -153,12 +163,17 @@ CommandArgs _parseArgs(List<String> args) {
   if (env != 'stable' && env != 'pre') {
     throw ArgumentError('Invalid --env value: $env');
   }
+  if (versionName != null &&
+      !RegExp(r'^\d+(?:\.\d+)*(?:-[0-9A-Za-z.-]+)?$').hasMatch(versionName)) {
+    throw ArgumentError('Invalid --version-name value: $versionName');
+  }
 
   return CommandArgs(
     target: args.first,
     arch: arch.isEmpty ? null : arch,
     env: env,
     out: out,
+    versionName: versionName,
   );
 }
 
@@ -240,6 +255,7 @@ Future<void> _buildAndroidCore({
 Future<void> _buildAndroidArtifacts({
   required String env,
   required String coreVersion,
+  required String? versionName,
 }) async {
   final dist = Directory(_projectPath(_distDir));
   _resetDistDirectory(dist);
@@ -250,18 +266,21 @@ Future<void> _buildAndroidArtifacts({
     flutterEnvironment: flutterEnvironment,
     env: env,
     coreVersion: coreVersion,
+    versionName: versionName,
   );
   await _buildUniversalApk(
     dist: dist,
     flutterEnvironment: flutterEnvironment,
     env: env,
     coreVersion: coreVersion,
+    versionName: versionName,
   );
   await _buildAppBundle(
     dist: dist,
     flutterEnvironment: flutterEnvironment,
     env: env,
     coreVersion: coreVersion,
+    versionName: versionName,
   );
 }
 
@@ -269,6 +288,7 @@ Future<void> _buildAndroidArtifact({
   required String out,
   required String env,
   required String coreVersion,
+  required String? versionName,
 }) async {
   final dist = Directory(_projectPath(_distDir));
   _resetDistDirectory(dist);
@@ -281,6 +301,7 @@ Future<void> _buildAndroidArtifact({
         flutterEnvironment: flutterEnvironment,
         env: env,
         coreVersion: coreVersion,
+        versionName: versionName,
       );
       break;
     case 'universal-apk':
@@ -289,6 +310,7 @@ Future<void> _buildAndroidArtifact({
         flutterEnvironment: flutterEnvironment,
         env: env,
         coreVersion: coreVersion,
+        versionName: versionName,
       );
       break;
     case 'appbundle':
@@ -297,6 +319,7 @@ Future<void> _buildAndroidArtifact({
         flutterEnvironment: flutterEnvironment,
         env: env,
         coreVersion: coreVersion,
+        versionName: versionName,
       );
       break;
     default:
@@ -316,6 +339,7 @@ Future<void> _buildSplitApks({
   required Map<String, String> flutterEnvironment,
   required String env,
   required String coreVersion,
+  required String? versionName,
 }) async {
   await _exec(
     [
@@ -326,6 +350,7 @@ Future<void> _buildSplitApks({
       '--split-per-abi',
       '--dart-define=APP_ENV=$env',
       '--dart-define=CORE_VERSION=$coreVersion',
+      if (versionName != null) '--build-name=$versionName',
     ],
     environment: flutterEnvironment,
     workingDirectory: _projectRoot,
@@ -355,6 +380,7 @@ Future<void> _buildUniversalApk({
   required Map<String, String> flutterEnvironment,
   required String env,
   required String coreVersion,
+  required String? versionName,
 }) async {
   await _exec(
     [
@@ -364,6 +390,7 @@ Future<void> _buildUniversalApk({
       '--release',
       '--dart-define=APP_ENV=$env',
       '--dart-define=CORE_VERSION=$coreVersion',
+      if (versionName != null) '--build-name=$versionName',
     ],
     environment: flutterEnvironment,
     workingDirectory: _projectRoot,
@@ -384,6 +411,7 @@ Future<void> _buildAppBundle({
   required Map<String, String> flutterEnvironment,
   required String env,
   required String coreVersion,
+  required String? versionName,
 }) async {
   await _exec(
     [
@@ -393,6 +421,7 @@ Future<void> _buildAppBundle({
       '--release',
       '--dart-define=APP_ENV=$env',
       '--dart-define=CORE_VERSION=$coreVersion',
+      if (versionName != null) '--build-name=$versionName',
     ],
     environment: flutterEnvironment,
     workingDirectory: _projectRoot,
@@ -1038,10 +1067,12 @@ class CommandArgs {
     this.arch,
     this.env = 'pre',
     this.out = 'app',
+    this.versionName,
   });
 
   final String target;
   final String? arch;
   final String env;
   final String out;
+  final String? versionName;
 }

--- a/tool/check_release_continuity.dart
+++ b/tool/check_release_continuity.dart
@@ -304,6 +304,20 @@ void _checkBuildWorkflow({
   );
   _expectPatternExists(
     content: content,
+    pattern: RegExp(r'version_name="\$\{GITHUB_REF_NAME#v\}"'),
+    label:
+        'package version derivation from the release tag in `$buildWorkflowPath`',
+    failures: failures,
+  );
+  _expectPatternExists(
+    content: content,
+    pattern: RegExp(r'--version-name\s+"\$version_name"'),
+    label:
+        'release tag version forwarding to Android builds in `$buildWorkflowPath`',
+    failures: failures,
+  );
+  _expectPatternExists(
+    content: content,
     pattern: RegExp(
       r'dart\s+tool/check_android_release_signing\.dart\s+dist/FlClashM-android-arm64-v8a\.apk',
     ),
@@ -354,6 +368,12 @@ void _checkSetupContract({
     pattern: RegExp(r"const _appName = '([^']+)';"),
     expected: contract.appName,
     label: 'release app name in `$setupPath`',
+    failures: failures,
+  );
+  _expectPatternExists(
+    content: content,
+    pattern: RegExp(r"'--build-name=\$versionName'"),
+    label: 'Android package version override in `$setupPath`',
     failures: failures,
   );
 


### PR DESCRIPTION
## Что изменено

- версия Android-пакета берётся из тега выпуска без начального `v`;
- предварительная сборка получает версию вида `0.10.5-pre3`;
- проверка договора выпуска контролирует передачу версии в сборку.

## Проверки

- `dart tool/check_release_continuity.dart`
- `dart tool/check_product_boundaries.dart`
- `flutter test test/product` — 162 теста
- `dart tool/check_base_drift.dart`