### PR TITLE
Убрать дубли двоичных файлов из ресурсов Android

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,19 +94,7 @@ flutter:
     - assets/fonts/
     - assets/images/
     - assets/images/avatars/
-    - assets/runtimes/
-    - assets/runtimes/naiveproxy/android/
-    - assets/runtimes/naiveproxy/android/armeabi-v7a/
-    - assets/runtimes/naiveproxy/android/arm64-v8a/
-    - assets/runtimes/naiveproxy/android/x86_64/
-    - assets/runtimes/olcrtc/android/
-    - assets/runtimes/olcrtc/android/armeabi-v7a/
-    - assets/runtimes/olcrtc/android/arm64-v8a/
-    - assets/runtimes/olcrtc/android/x86_64/
-    - assets/runtimes/byedpi/android/
-    - assets/runtimes/byedpi/android/armeabi-v7a/
-    - assets/runtimes/byedpi/android/arm64-v8a/
-    - assets/runtimes/byedpi/android/x86_64/
+    - assets/runtimes/byedpi/android/byebyeedpi-strategies.list
     - assets/images/icons/
   fonts:
     - family: JetBrainsMono

--- a/test/product/runtime/runtime_asset_packaging_test.dart
+++ b/test/product/runtime/runtime_asset_packaging_test.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Flutter assets contain only runtime data required at runtime', () {
+    final pubspec = File('pubspec.yaml').readAsLinesSync();
+    final runtimeAssets = pubspec
+        .map((line) => line.trim())
+        .where((line) => line.startsWith('- assets/runtimes/'))
+        .toList();
+
+    expect(runtimeAssets, const [
+      '- assets/runtimes/byedpi/android/byebyeedpi-strategies.list',
+    ]);
+  });
+}


### PR DESCRIPTION
## Что изменено

- двоичные файлы встроенных узлов исключены из ресурсов Flutter
- список стратегий ByeDPI оставлен доступным через `rootBundle`
- добавлен тест состава ресурсов среды выполнения

## Проверки

- `dart tool/check_product_boundaries.dart`
- `flutter test --no-pub test/product` — 178 тестов
- выпускная сборка `arm64-v8a` — 70,6 МБ
- в `flutter_assets` нет двоичных файлов среды выполнения
- JNI-библиотеки ByeDPI, NaiveProxy и OlcRTC присутствуют в `lib/arm64-v8a`

`check_base_drift.dart` пропущен самим скриптом: локальная ссылка `upstream/dev` недоступна.