### PR TITLE
Обновить стратегии ByeDPI

### DIFF
--- a/assets/runtimes/byedpi/android/byebyeedpi-strategies.list
+++ b/assets/runtimes/byedpi/android/byebyeedpi-strategies.list
@@ -1,60 +1,39 @@
--l:"\xC2\x00\x00\x00\x01\x14\x2E\xE3\xE3\x5F\x6B\xBB\x23\xA8\xE6\x5D\xA9\x78\x21\xCF\xC2\x72\x4C\x8F\xC4\x5E\x14\x00\x00\x00\x00\xC5\x00\x00\x00\x00\x4C\x00\xA7\x00\x00\x00\x00\x00\x00\x44\x00\x00\x80\x00\x00\x00\x0D\xFC\xFA\x1D\xCD\x73\xBA\x2A\x90\x93\xB3\xEE\xF7\x43\xC5\x85\xDA\xFF\x45\x3C\x00\x00\x00\x00\x00\x00\x7C\x00\x9B\x00\xF6\x00\x00\xDD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x59\xA8\xE4\x00\x00\x00\x00\x00\x00\x00\x00\x7B\x00\x0F\x00\x00\x00\x48\x4E\x00\x00\x00\x06\xF3\x00\x00\x00\x00\xD9\x5A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" -a3 -t12 -d1 -s0+h -d3+s -s6+s -d5+s -s8+s -d7+s -s10+s -d3 -At,s -r3
 -f-200 -Qr -s3:5+sm -a1 -As -d1 -s4+sm -s8+sh -f-300 -d6+sh -a1 -At,r,s -o2 -f-30 -As -r5 -Mh -r6+sh -f-250 -s2:7+s -s3:6+sm -a1 -At,r,s -s3:5+sm -s6+s -s7:9+s -q30+sm -a1
 -d1 -d3+s -s6+s -d9+s -s12+s -d15+s -s20+s -d25+s -s30+s -d35+s -r1+s -S -a1 -As -d1 -d3+s -s6+s -d9+s -s12+s -d15+s -s20+s -d25+s -s30+s -d35+s -S -a1
 -q2 -s2 -s3+s -r3 -s4 -r4 -s5+s -r5+s -s6 -s7+s -r8 -s9+s -Qr -Mh,d,r -a1 -At,r -s2+s -r2 -d2 -s3 -r3 -r4 -s4 -d5+s -r5 -d6 -s7+s -d7 -a1
--Ku -l:"\xe3\x00\x06\xec\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" -a3 -An -f64+se -n {sni} -t5
 -o1 -d1 -a1 -At,r,s -s1 -d1 -s5+s -s10+s -s15+s -s20+s -r1+s -S -a1 -As -s1 -d1 -s5+s -s10+s -s15+s -s20+s -S -a1
 -n {sni} -Qr -f-204 -s1:5+sm -a1 -As -d1 -s3+s -s5+s -q7 -a1 -As -o2 -f-43 -a1 -As -r5 -Mh -s1:5+s -s3:7+sm -a1
 -n {sni} -Qr -f-205 -a1 -As -s1:3+sm -a1 -As -s5:8+sm -a1 -As -d3 -q7 -o2 -f-43 -f-85 -f-165 -r5 -Mh -a1
 -d1+s -s50+s -a1 -As -f20 -r2+s -a1 -At -d2 -s1+s -s5+s -s10+s -s15+s -s25+s -s35+s -s50+s -s60+s -a1
 -o1 -a1 -At,r,s -f-1 -a1 -At,r,s -d1:11+sm -S -a1 -At,r,s -n {sni} -Qr -f1 -d1:11+sm -s1:11+sm -S -a1
--d1 -s1 -q1 -Y -a1 -Ar -s5 -o1+s -d3+s -s6+s -d9+s -s12+s -d15+s -s20+s -d25+s -s30+s -d35+s -a1
+-d1 -s1 -q1 -a1 -Ar -s5 -o1+s -d3+s -s6+s -d9+s -s12+s -d15+s -s20+s -d25+s -s30+s -d35+s -a1
 -f1+nme -t6 -a1 -As -n {sni} -Qr -s1:6+sm -a1 -As -s5:12+sm -a1 -As -d3 -q7 -r6 -Mh -a1
--s1 -o1 -a1 -Y -Ar -s5 -o1+s -a1 -At -f-1 -r1+s -a1 -As -s1 -o1+s -s-1 -a1
--s1 -d1 -a1 -Y -Ar -d5 -o1+s -a1 -At -f-1 -r1+s -a1 -As -d1 -o1+s -s-1 -a1
 -d1 -s1+s -d3+s -s6+s -d9+s -s12+s -d15+s -s20+s -d25+s -s30+s -d35+s -a1
--s1 -q1 -a1 -Y -Ar -a1 -s5 -o2 -At -f-1 -r1+s -a1 -As -s1 -o1+s -s-1 -a1
--s1 -q1 -a1 -Ar -s5 -o1+s -a1 -At -f-1 -d1+s -a1 -As -s1 -o1+s -s-1 -a1
--s1 -q1 -a1 -Ar -s5 -o2 -a1 -At -f-1 -r1+s -a1 -As -s1 -o1+s -s-1 -a1
 -d1 -s1+s -d1+s -s3+s -d6+s -s12+s -d14+s -s20+s -d24+s -s30+s -a1
--s1 -q1 -a1 -Y -At -a1 -S -f-1 -r1+s -a1 -As -d1+s -O1 -s29+s -a1
 -o1 -a1 -At,r,s -f-1 -a1 -Ar,s -o1 -a1 -At -r1+s -f-1 -t6 -a1
 -d1 -s1+s -s3+s -s6+s -s9+s -s12+s -s15+s -s20+s -s30+s -a1
+-d1 -d3+s -s6+s -d6+s -s7+s -d8+s -s10+s -a1 -t12 -At,s -r3
 -f1 -t5 -n {sni} -q3+h -Qr -f2 -q1 -r1+s -t15 -q1 -o2 -a1
 -n {sni} -d2:5:2+h -f-3 -r2+sm -o2 -o50+s -r2+s -f-4 -a1
--r-1+s -o20+sm -s3:7+sm -d5:3+sm -f300+s -Qr -Y -f-1 -a1
 -f-1 -Qr -s1+sm -d3+s -s5+sm -o2 -a1 -As -r1+s -d8+s -a1
--s25 -r5+s -s25+s -a1 -At,r,s -s50 -r5+s -s50+s -a1
--o2 -O4 -s1 -q1 -a2 -Ar -s5 -o1+s -f1+s -r20+s -a2
+-r-1+s -o20+sm -s3:7+sm -d5:3+sm -f300+s -Qr -f-1 -a1
+-o2 -O4 -s1 -q1 -a1 -Ar -s5 -o1+s -f1+s -r20+s -a1
 -o1 -r-5+se -a1 -At,r,s -d1 -n {sni} -Qr -f-1 -a1
 --fake -1 --ttl 8 --split 1+s --disorder 3+s -a1
--s1 -d1 -r1+s -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
--s1 -q1 -r1+s -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
--s1 -o1 -r1+s -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
 -n {sni} -Qr -f6+nr -d2 -d11 -f9+hm -o3 -t7 -a1
+-r5+s -s25+s -a1 -At,r,s -s50 -r5+s -s50+s -a1
 -d1 -d3+s -s6+s -d9+s -s20+s -d25+s -s30+s -a1
--s1 -d1 -o1 -a1 -Ar -o3 -a1 -At -f-1 -r1+s -a1
 -d9+s -q20+s -s25+s -t5 -a1 -At,r,s -r1+h -a1
 -q1+s -s29+s -s30+s -s14+s -o5+s -f-1 -S -a1
 -d1 -s1+s -r1+s -e1 -m1 -o1+s -f-1 -t2 -a1
--d9+s -q20+s -s 25+s -t5 -At,r,s -r1+h -a1
--s1 -o1 -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
 -d1 -o1 -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
 -d1 -s4 -d8 -s1+s -d5+s -s10+s -d20+s -a1
--f-1 -n {sni} -Qr -s2+s -r3 -o20 -t4 -a7
+-f-1 -n {sni} -Qr -s2+s -r3 -o20 -t4 -a1
 -n {sni} -Qr -d5+sm -f3+sm -o2 -t4 -a1
 -o1 -a1 -Ar -q1 -a1 -At -f-1 -r1+s -a1
 -q1 -a1 -Ar -o1 -a1 -At -f-1 -r1+s -a1
--s1 -q1 -Y -a1 -At,r,s -f-1 -r1+s -a1
--s1 -o1 -Y -a1 -At,r,s -f-1 -r1+s -a1
--s1 -d1 -Y -a1 -At,r,s -f-1 -r1+s -a1
--n {sni} -Qr -f209 -s1+sm -R1-3 -a1
--s1 -q1 -a1 -At,r,s -f-1 -r1+s -a1
--s1 -o1 -a1 -At,r,s -f-1 -r1+s -a1
--s1 -d1 -a1 -At,r,s -f-1 -r1+s -a1
 -s4+sn -r9+s -Qr -n {sni} -S -a1
 -o1 -d1 -r1+s -S -s1+s -d3+s -a1
--d1 -r1+s -f-1 -S -t8 -o3+s -a1
 -q1+s -s29+s -o5+s -f-1 -S -a1
 -n {sni} -Qr -m2 -f-1 -d7 -a1
 -d1 -s1+s -r1+s -f-1 -t8 -a1
@@ -62,16 +41,17 @@
 -n {sni} -Qr -f-1 -r1+s -a1
 -n {sni} -Qr -d1:3 -f-1 -a1
 -s1 -d3+s -a1 -At -r1+s -a1
--f-1 -t8 -n {sni} -s1+s -a5
+-f-1 -t8 -n {sni} -s1+s -a1
+-n {sni} -Qr -d1 -f-1 -a1
+-f64+se -n {sni} -t5 -a1
 -o1 -a1 -At,r,s -d1 -a1
--n {sni} -Qr -d1 -f-1
 -d1+s -o2 -s5 -r5 -a1
 -r8 -o2 -s7 -q4+s -a1
+-o1 -f-1 -r-5+se -a1
 -d6+s -q4+hm -o2 -a1
--f-1+sm -t7 -a5 -m2
--o1 -a1 -r-5+se
--s1+s -d3+s -a1
--s1 -f-1 -S -a1
+-s5+s -s35+s -m4 -a1
+-f-1+sm -t7 -m2 -a1
+-o1 -r-5+se -a1
 -o1+s -d3+s -a1
 -o1 -s4 -s6 -a1
 -q1 -r25+s -a1

--- a/assets/runtimes/byedpi/android/release.txt
+++ b/assets/runtimes/byedpi/android/release.txt
@@ -1,7 +1,7 @@
 git-ba532298de7b28cfe854aea83d061369d13ca290
 https://github.com/hufrea/byedpi.git
 https://github.com/romanvht/ByeByeDPI.git
-47ae0226f13eff48f8c83a0b33300b81cce13214
+4a0dabe94297fc7040d015a12b4c217837714628
 armeabi-v7a:arm
 arm64-v8a:arm64
 x86_64:amd64

--- a/lib/product/runtime/byedpi_release.dart
+++ b/lib/product/runtime/byedpi_release.dart
@@ -3,7 +3,7 @@ const byedpiPinnedReleaseTag = 'git-$byedpiPinnedCommit';
 const byedpiSourceRepository = 'https://github.com/hufrea/byedpi.git';
 const byedpiStrategySourceRepository =
     'https://github.com/romanvht/ByeByeDPI.git';
-const byedpiStrategyPinnedCommit = '47ae0226f13eff48f8c83a0b33300b81cce13214';
+const byedpiStrategyPinnedCommit = '4a0dabe94297fc7040d015a12b4c217837714628';
 const byedpiBundledAssetRoot = 'assets/runtimes/byedpi/android';
 const byedpiRuntimeDirectoryName = 'byedpi';
 const byedpiExecutableFileName = 'ciadpi';


### PR DESCRIPTION
## Что изменено

- список стратегий ByeDPI синхронизирован с `romanvht/ByeByeDPI`;
- закреплённая ревизия обновлена до `4a0dabe94297fc7040d015a12b4c217837714628`;
- отметка состава Android-ресурсов обновлена вместе со списком.

## Зачем

Встроенный список отставал от актуального источника. Обновление добавляет новые варианты, исправляет параметры и удаляет устаревшие стратегии.

## Проверки

- точное совпадение файла с закреплённой ревизией источника;
- `dart tool/check_product_boundaries.dart`;
- `flutter test test/product` — 189 тестов;
- `dart tool/check_base_drift.dart`;
- `git diff --check`.
