### PR TITLE
Исправить генератор каталога выпуска

### DIFF
--- a/lib/product/android/android_update_bridge.dart
+++ b/lib/product/android/android_update_bridge.dart
@@ -12,6 +12,8 @@ import '../../plugins/app.dart';
 import '../../state.dart';
 import '../../widgets/dialog.dart';
 import '../services/app_update_manifest.dart';
+import '../services/app_update_manifest_release.dart';
+import '../services/app_update_manifest_rollback.dart';
 import '../services/app_update_release.dart';
 
 final Dio _appUpdateDio = Dio(

--- a/lib/product/services/app_update_manifest.dart
+++ b/lib/product/services/app_update_manifest.dart
@@ -1,9 +1,6 @@
 import 'dart:convert';
 
 import 'package:cryptography/cryptography.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-
-import 'app_update_release.dart';
 
 const appUpdateManifestSchemaVersion = 1;
 const appUpdateManifestPublicKeyBase64 =
@@ -15,6 +12,9 @@ const sourceForgeUpdateRootUrl =
     'https://$sourceForgeProjectName.sourceforge.io/update';
 final appUpdateReleaseTagPattern =
     RegExp(r'^v\d+(?:\.\d+)*(?:-[0-9A-Za-z.-]+)?$');
+final appUpdateAndroidApkAssetPattern = RegExp(
+  r'-android(?:-([A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*))?\.apk$',
+);
 
 enum AppUpdateChannel {
   stable('stable'),
@@ -133,15 +133,6 @@ class AppUpdateManifest {
           'assets': assets.map((asset) => asset.toJson()).toList(),
         },
       };
-
-  AppRelease toRelease() => AppRelease(
-        tagName: tagName,
-        body: body,
-        htmlUrl: htmlUrl,
-        assets: assets.map((asset) => asset.toReleaseAsset()).toList(),
-        prerelease: channel == AppUpdateChannel.prerelease,
-        draft: false,
-      );
 }
 
 class AppUpdateManifestAsset {
@@ -178,14 +169,7 @@ class AppUpdateManifestAsset {
       return url;
     }).toList(growable: false);
 
-    final releaseAsset = ReleaseAsset(
-      name: name,
-      browserDownloadUrl: urls.first,
-      downloadUrls: urls,
-      size: size,
-      digest: 'sha256:$sha256',
-    );
-    if (!releaseAsset.isAndroidApk) {
+    if (!isAppUpdateAndroidApkAssetName(name)) {
       throw const FormatException('Manifest asset is not an Android APK.');
     }
 
@@ -208,14 +192,6 @@ class AppUpdateManifestAsset {
         'sha256': sha256,
         'urls': urls,
       };
-
-  ReleaseAsset toReleaseAsset() => ReleaseAsset(
-        name: name,
-        browserDownloadUrl: urls.first,
-        downloadUrls: urls,
-        size: size,
-        digest: 'sha256:$sha256',
-      );
 }
 
 class AppUpdateManifestVerifier {
@@ -257,70 +233,6 @@ class AppUpdateManifestVerifier {
   }
 }
 
-abstract interface class AppUpdateManifestRollbackGuard {
-  Future<void> validateAndRecord(AppUpdateManifest manifest);
-}
-
-class SharedPreferencesAppUpdateManifestRollbackGuard
-    implements AppUpdateManifestRollbackGuard {
-  const SharedPreferencesAppUpdateManifestRollbackGuard();
-
-  static const _keyPrefix = 'flclashm.appUpdate.highestManifest';
-
-  @override
-  Future<void> validateAndRecord(AppUpdateManifest manifest) async {
-    final preferences = await SharedPreferences.getInstance();
-    final channelKey = '$_keyPrefix.${manifest.channel.wireName}';
-    final highest = _readHighestManifestState(
-      preferences.getString(channelKey),
-    );
-    final publishedAt = manifest.publishedAt.millisecondsSinceEpoch;
-
-    if (manifest.versionCode < highest.versionCode ||
-        (manifest.versionCode == highest.versionCode &&
-            publishedAt < highest.publishedAtMillis)) {
-      throw const FormatException('App update manifest rollback rejected.');
-    }
-    if (manifest.versionCode > highest.versionCode ||
-        publishedAt > highest.publishedAtMillis) {
-      final stored = await preferences.setString(
-        channelKey,
-        jsonEncode({
-          'versionCode': manifest.versionCode,
-          'publishedAtMillis': publishedAt,
-        }),
-      );
-      if (!stored) {
-        throw StateError('Unable to persist app update rollback state.');
-      }
-    }
-  }
-}
-
-({int versionCode, int publishedAtMillis}) _readHighestManifestState(
-  String? raw,
-) {
-  if (raw == null) {
-    return (versionCode: 0, publishedAtMillis: 0);
-  }
-  final decoded = jsonDecode(raw);
-  if (decoded is! Map<String, dynamic>) {
-    throw const FormatException('Invalid app update rollback state.');
-  }
-  final versionCode = decoded['versionCode'];
-  final publishedAtMillis = decoded['publishedAtMillis'];
-  if (versionCode is! int ||
-      versionCode < 0 ||
-      publishedAtMillis is! int ||
-      publishedAtMillis < 0) {
-    throw const FormatException('Invalid app update rollback state.');
-  }
-  return (
-    versionCode: versionCode,
-    publishedAtMillis: publishedAtMillis,
-  );
-}
-
 String appUpdateManifestUrl(AppUpdateChannel channel) =>
     '$sourceForgeUpdateRootUrl/${channel.wireName}.json';
 
@@ -332,6 +244,9 @@ bool appUpdateReleaseTagMatchesChannel(
   AppUpdateChannel channel,
 ) =>
     (channel == AppUpdateChannel.prerelease) == tagName.contains('-');
+
+bool isAppUpdateAndroidApkAssetName(String name) =>
+    appUpdateAndroidApkAssetPattern.hasMatch(name);
 
 String _requiredString(Map<String, dynamic> json, String key) {
   final value = json[key];

--- a/lib/product/services/app_update_manifest_release.dart
+++ b/lib/product/services/app_update_manifest_release.dart
@@ -1,0 +1,23 @@
+import 'app_update_manifest.dart';
+import 'app_update_release.dart';
+
+extension AppUpdateManifestReleaseMapping on AppUpdateManifest {
+  AppRelease toRelease() => AppRelease(
+        tagName: tagName,
+        body: body,
+        htmlUrl: htmlUrl,
+        assets: assets.map((asset) => asset.toReleaseAsset()).toList(),
+        prerelease: channel == AppUpdateChannel.prerelease,
+        draft: false,
+      );
+}
+
+extension AppUpdateManifestAssetReleaseMapping on AppUpdateManifestAsset {
+  ReleaseAsset toReleaseAsset() => ReleaseAsset(
+        name: name,
+        browserDownloadUrl: urls.first,
+        downloadUrls: urls,
+        size: size,
+        digest: 'sha256:$sha256',
+      );
+}

--- a/lib/product/services/app_update_manifest_rollback.dart
+++ b/lib/product/services/app_update_manifest_rollback.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'app_update_manifest.dart';
+
+abstract interface class AppUpdateManifestRollbackGuard {
+  Future<void> validateAndRecord(AppUpdateManifest manifest);
+}
+
+class SharedPreferencesAppUpdateManifestRollbackGuard
+    implements AppUpdateManifestRollbackGuard {
+  const SharedPreferencesAppUpdateManifestRollbackGuard();
+
+  static const _keyPrefix = 'flclashm.appUpdate.highestManifest';
+
+  @override
+  Future<void> validateAndRecord(AppUpdateManifest manifest) async {
+    final preferences = await SharedPreferences.getInstance();
+    final channelKey = '$_keyPrefix.${manifest.channel.wireName}';
+    final highest = _readHighestManifestState(
+      preferences.getString(channelKey),
+    );
+    final publishedAt = manifest.publishedAt.millisecondsSinceEpoch;
+
+    if (manifest.versionCode < highest.versionCode ||
+        (manifest.versionCode == highest.versionCode &&
+            publishedAt < highest.publishedAtMillis)) {
+      throw const FormatException('App update manifest rollback rejected.');
+    }
+    if (manifest.versionCode > highest.versionCode ||
+        publishedAt > highest.publishedAtMillis) {
+      final stored = await preferences.setString(
+        channelKey,
+        jsonEncode({
+          'versionCode': manifest.versionCode,
+          'publishedAtMillis': publishedAt,
+        }),
+      );
+      if (!stored) {
+        throw StateError('Unable to persist app update rollback state.');
+      }
+    }
+  }
+}
+
+({int versionCode, int publishedAtMillis}) _readHighestManifestState(
+  String? raw,
+) {
+  if (raw == null) {
+    return (versionCode: 0, publishedAtMillis: 0);
+  }
+  final decoded = jsonDecode(raw);
+  if (decoded is! Map<String, dynamic>) {
+    throw const FormatException('Invalid app update rollback state.');
+  }
+  final versionCode = decoded['versionCode'];
+  final publishedAtMillis = decoded['publishedAtMillis'];
+  if (versionCode is! int ||
+      versionCode < 0 ||
+      publishedAtMillis is! int ||
+      publishedAtMillis < 0) {
+    throw const FormatException('Invalid app update rollback state.');
+  }
+  return (
+    versionCode: versionCode,
+    publishedAtMillis: publishedAtMillis,
+  );
+}

--- a/test/product/services/app_update_manifest_test.dart
+++ b/test/product/services/app_update_manifest_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flclashx/product/services/app_update_manifest.dart';
+import 'package:flclashx/product/services/app_update_manifest_release.dart';
+import 'package:flclashx/product/services/app_update_manifest_rollback.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/test/tool/write_app_update_manifest_test.dart
+++ b/test/tool/write_app_update_manifest_test.dart
@@ -93,4 +93,38 @@ void main() {
       throwsFormatException,
     );
   });
+
+  test('starts under the standalone Dart VM used by the release workflow',
+      () async {
+    final tempDir = Directory.systemTemp.createTempSync('update-manifest-vm-');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final dist = Directory('${tempDir.path}/dist')..createSync();
+    File('${dist.path}/FlClashM-android-arm64-v8a.apk')
+        .writeAsBytesSync([1, 2, 3]);
+    final notes = File('${tempDir.path}/release.md')
+      ..writeAsStringSync('- Проверка запуска\n');
+    final result = await Process.run(
+      'dart',
+      [
+        'tool/write_app_update_manifest.dart',
+        '--dist=${dist.path}',
+        '--out=${tempDir.path}/pre.json',
+        '--release-notes=${notes.path}',
+        '--tag=v0.10.5-pre7',
+        '--github-repository=makriq-org/FlClashM',
+        '--channel=pre',
+        '--published-at=2026-07-14T10:00:00.000Z',
+      ],
+      workingDirectory: Directory.current.path,
+      environment: {
+        ...Platform.environment,
+        'APP_UPDATE_SIGNING_KEY': base64Encode(List<int>.filled(32, 1)),
+      },
+    );
+    final output = '${result.stdout}\n${result.stderr}';
+
+    expect(result.exitCode, isNot(0));
+    expect(output, contains('does not match the embedded public key'));
+    expect(output, isNot(contains("Dart library 'dart:ui' is not available")));
+  });
 }

--- a/tool/write_app_update_manifest.dart
+++ b/tool/write_app_update_manifest.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:flclashx/product/services/app_update_manifest.dart';
-import 'package:flclashx/product/services/app_update_release.dart';
 
 import 'release_contract.dart';
 
@@ -59,12 +58,7 @@ Future<AppUpdateManifest> buildAppUpdateManifest(
     ..sort((left, right) => left.path.compareTo(right.path));
   for (final file in files) {
     final name = file.uri.pathSegments.last;
-    final releaseAsset = ReleaseAsset(
-      name: name,
-      browserDownloadUrl: 'https://invalid.example',
-      size: file.lengthSync(),
-    );
-    if (!releaseAsset.isAndroidApk) {
+    if (!isAppUpdateAndroidApkAssetName(name)) {
       continue;
     }
     final digest = await sha256.bind(file.openRead()).first;


### PR DESCRIPTION
## Причина

Сборка `v0.10.5-pre7` дошла до формирования подписанного каталога обновлений, но генератор запускался обычным Dart и косвенно загружал Flutter-зависимости через `shared_preferences` и модель выпуска. Из-за недоступного `dart:ui` шаг завершался ошибкой до публикации.

## Изменения

- отделён чистый контракт каталога от привязок к Flutter;
- преобразование в модель выпуска и защита от отката вынесены в отдельные файлы;
- проверка имён APK доступна генератору без Flutter;
- добавлена проверка запуска генератора обычным Dart.

## Проверка

- `nix develop -c make check`
- 224 теста пройдены;
- анализ кода, границы слоёв и контроль дрейфа пройдены.