### PR TITLE
Устранить гонки фонового подбора ByeDPI

### DIFF
--- a/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeProcessManager.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeProcessManager.kt
@@ -12,9 +12,11 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -163,15 +165,19 @@ object RuntimeNodeProcessManager {
     )
 
     private val planLock = Mutex()
+    private val planTransitionLock = Mutex()
     private val nodeLocks = ConcurrentHashMap<String, Mutex>()
     private val runningNodes = ConcurrentHashMap<String, RunningNode>()
+    private val activeBatchProbeJobs = mutableSetOf<Job>()
     private val readyNodeIds = ConcurrentHashMap.newKeySet<String>()
     private var activePlan = linkedMapOf<String, RuntimeNodeSpec>()
+    private var acceptingBatchProbes = true
     @Volatile private var generation = 0L
     private var optionalCheckJob: Job? = null
     @Volatile private var lastStateJson = stateJson(0L, "idle", emptyList())
 
-    suspend fun applyPlan(planJson: String): String = planLock.withLock {
+    suspend fun applyPlan(planJson: String): String =
+        withBatchProbesStopped {
         val target = parsePlan(planJson)
         val previousPlan = activePlan
         val previousReady = readyNodeIds.toSet()
@@ -187,7 +193,7 @@ object RuntimeNodeProcessManager {
                 if (target.isEmpty()) "idle" else "ready",
                 target.values.map { NodeOutcome(it, ready = true, reused = true) },
             )
-            return@withLock lastStateJson
+            return@withBatchProbesStopped lastStateJson
         }
 
         generation += 1L
@@ -224,7 +230,7 @@ object RuntimeNodeProcessManager {
                 outcomes,
                 failure.message.ifBlank { "Runtime node `${failure.spec.nodeId}` is not ready" },
             )
-            return@withLock lastStateJson
+            return@withBatchProbesStopped lastStateJson
         }
 
         activePlan = LinkedHashMap(target)
@@ -245,6 +251,7 @@ object RuntimeNodeProcessManager {
     }
 
     suspend fun probeNode(nodeJson: String): Boolean = planLock.withLock {
+        check(acceptingBatchProbes) { "Runtime-node plan transition is in progress" }
         val spec = RuntimeNodeSpec.fromJson(JSONObject(nodeJson), 0)
         require(
             !activePlan.containsKey(spec.nodeId) &&
@@ -272,30 +279,45 @@ object RuntimeNodeProcessManager {
         require(values.length() in 1..MAX_PROBE_NODES) {
             "Runtime-node probe batch must contain between 1 and $MAX_PROBE_NODES nodes"
         }
+        val probeJob = checkNotNull(currentCoroutineContext()[Job])
         val specs = planLock.withLock {
-            buildList {
-                val nodeIds = mutableSetOf<String>()
-                for (index in 0 until values.length()) {
-                    val spec = RuntimeNodeSpec.fromJson(values.getJSONObject(index), index)
-                    require(nodeIds.add(spec.nodeId)) {
-                        "Runtime-node probe `${spec.nodeId}` is duplicated"
+            check(acceptingBatchProbes) { "Runtime-node plan transition is in progress" }
+            try {
+                buildList {
+                    val nodeIds = mutableSetOf<String>()
+                    for (index in 0 until values.length()) {
+                        val spec = RuntimeNodeSpec.fromJson(values.getJSONObject(index), index)
+                        require(nodeIds.add(spec.nodeId)) {
+                            "Runtime-node probe `${spec.nodeId}` is duplicated"
+                        }
+                        require(
+                            !activePlan.containsKey(spec.nodeId) &&
+                                !runningNodes.containsKey(spec.nodeId),
+                        ) {
+                            "Runtime-node probe `${spec.nodeId}` conflicts with an active node"
+                        }
+                        require(spec.connectivityCheck.required && spec.connectivityCheck.urls.isNotEmpty()) {
+                            "Runtime-node probe `${spec.nodeId}` requires a connectivity check"
+                        }
+                        add(spec)
                     }
-                    require(
-                        !activePlan.containsKey(spec.nodeId) &&
-                            !runningNodes.containsKey(spec.nodeId),
-                    ) {
-                        "Runtime-node probe `${spec.nodeId}` conflicts with an active node"
-                    }
-                    require(spec.connectivityCheck.required && spec.connectivityCheck.urls.isNotEmpty()) {
-                        "Runtime-node probe `${spec.nodeId}` requires a connectivity check"
-                    }
-                    add(spec)
+                }.also {
+                    activeBatchProbeJobs.add(probeJob)
                 }
+            } catch (error: Throwable) {
+                activeBatchProbeJobs.remove(probeJob)
+                throw error
             }
         }
 
-        return selectRuntimeNodeProbeIndex(specs.size, concurrency) { index ->
-            probeNodeOnce(specs[index])
+        return try {
+            selectRuntimeNodeProbeIndex(specs.size, concurrency) { index ->
+                probeNodeOnce(specs[index])
+            }
+        } finally {
+            withContext(NonCancellable) {
+                planLock.withLock { activeBatchProbeJobs.remove(probeJob) }
+            }
         }
     }
 
@@ -305,7 +327,7 @@ object RuntimeNodeProcessManager {
             .toString()
     }.getOrDefault(lastStateJson)
 
-    suspend fun stopAll() = planLock.withLock {
+    suspend fun stopAll() = withBatchProbesStopped {
         optionalCheckJob?.cancelAndJoin()
         optionalCheckJob = null
         stopAllProcesses()
@@ -314,6 +336,26 @@ object RuntimeNodeProcessManager {
         generation += 1L
         lastStateJson = stateJson(generation, "idle", emptyList())
     }
+
+    private suspend fun <T> withBatchProbesStopped(block: suspend () -> T): T =
+        planTransitionLock.withLock {
+            val jobs = planLock.withLock {
+                acceptingBatchProbes = false
+                activeBatchProbeJobs.forEach { it.cancel() }
+                activeBatchProbeJobs.toList()
+            }
+            try {
+                withContext(NonCancellable) { jobs.joinAll() }
+                currentCoroutineContext().ensureActive()
+                planLock.withLock { block() }
+            } finally {
+                withContext(NonCancellable) {
+                    planLock.withLock {
+                        acceptingBatchProbes = true
+                    }
+                }
+            }
+        }
 
     suspend fun stopIfIdle(vpnActive: Boolean) {
         if (!vpnActive && !RuntimeNodeClientRegistry.hasClients) {

--- a/lib/product/runtime/built_in_proxy_supervisor.dart
+++ b/lib/product/runtime/built_in_proxy_supervisor.dart
@@ -73,13 +73,13 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
   @override
   Future<void> prepareForRestart() async {
     _planGeneration++;
-    byedpi.cancelBackgroundSelection();
+    await byedpi.cancelBackgroundSelection();
   }
 
   @override
   Future<String> stageRuntimePlan(List<BuiltInProxyNodePlan> plans) async {
     _planGeneration++;
-    byedpi.cancelBackgroundSelection();
+    await byedpi.cancelBackgroundSelection();
     final naiveMessage = await naiveProxy.stageRuntimePlan(
       currentPlans: _filter(_currentPlans, BuiltInProxyType.naiveproxy),
       nextPlans: _filter(plans, BuiltInProxyType.naiveproxy),
@@ -166,7 +166,7 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
   @override
   Future<void> stop() async {
     _planGeneration++;
-    byedpi.cancelBackgroundSelection();
+    await byedpi.cancelBackgroundSelection();
     await runtime.stopPlan();
   }
 

--- a/lib/product/runtime/byedpi_node_controller.dart
+++ b/lib/product/runtime/byedpi_node_controller.dart
@@ -296,6 +296,7 @@ class ByedpiNodeController
   final ByedpiProbePortAllocator allocateProbePort;
   final Map<String, _ByedpiPendingSelection> _pendingSelections = {};
   int _backgroundGeneration = 0;
+  Future<void>? _backgroundWorker;
 
   @override
   ByedpiBinaryBridge get binary => super.binary as ByedpiBinaryBridge;
@@ -442,9 +443,12 @@ class ByedpiNodeController
     return config.fallbackStrategy;
   }
 
-  void cancelBackgroundSelection({bool clearPending = true}) {
+  Future<void> cancelBackgroundSelection({bool clearPending = true}) async {
     _backgroundGeneration++;
     if (clearPending) _pendingSelections.clear();
+    final worker = _backgroundWorker;
+    await worker;
+    if (identical(_backgroundWorker, worker)) _backgroundWorker = null;
   }
 
   void startBackgroundSelection(
@@ -457,13 +461,31 @@ class ByedpiNodeController
         .toList(growable: false);
     if (pending.isEmpty) return;
     final generation = ++_backgroundGeneration;
-    for (final selection in pending) {
-      unawaited(
-        _continueSelection(
-          selection,
-          generation: generation,
-          onSelectionChanged: onSelectionChanged,
-        ),
+    final previousWorker = _backgroundWorker;
+    final worker = () async {
+      await previousWorker;
+      if (generation != _backgroundGeneration) return;
+      await _continueSelections(
+        pending,
+        generation: generation,
+        onSelectionChanged: onSelectionChanged,
+      );
+    }();
+    _backgroundWorker = worker;
+    unawaited(worker);
+  }
+
+  Future<void> _continueSelections(
+    List<_ByedpiPendingSelection> selections, {
+    required int generation,
+    required Future<bool> Function() onSelectionChanged,
+  }) async {
+    for (final selection in selections) {
+      if (generation != _backgroundGeneration) return;
+      await _continueSelection(
+        selection,
+        generation: generation,
+        onSelectionChanged: onSelectionChanged,
       );
     }
   }
@@ -844,12 +866,7 @@ class ByedpiNodeController
     final target = File(layout.cachePath);
     final temporary = File('${layout.cachePath}.tmp');
     await temporary.writeAsString(json.encode(cache.toJson()), flush: true);
-    try {
-      await temporary.rename(target.path);
-    } on FileSystemException {
-      if (target.existsSync()) await target.delete();
-      await temporary.rename(target.path);
-    }
+    await temporary.rename(target.path);
   }
 
   Future<void> _restoreCache(

--- a/test/product/android/runtime_node_lifecycle_contract_test.dart
+++ b/test/product/android/runtime_node_lifecycle_contract_test.dart
@@ -93,6 +93,39 @@ void main() {
     );
   });
 
+  test('plan transitions cancel and join registered batch probes', () {
+    final probe = manager.indexOf('suspend fun probeNodes');
+    final probeEnd = manager.indexOf('fun readPlanState', probe);
+    final batchProbe = manager.substring(probe, probeEnd);
+    final transition = manager.indexOf(
+      'private suspend fun <T> withBatchProbesStopped',
+    );
+    final transitionEnd = manager.indexOf('suspend fun stopIfIdle', transition);
+    final transitionBody = manager.substring(transition, transitionEnd);
+    final cancellationCheck =
+        transitionBody.indexOf('currentCoroutineContext().ensureActive()');
+    final planChange =
+        transitionBody.indexOf('planLock.withLock { block() }');
+
+    expect(batchProbe, contains('activeBatchProbeJobs.add(probeJob)'));
+    expect(batchProbe, contains('activeBatchProbeJobs.remove(probeJob)'));
+    expect(transition, greaterThan(0));
+    expect(manager, contains('activeBatchProbeJobs.forEach { it.cancel() }'));
+    expect(manager, contains('val jobs = planLock.withLock'));
+    expect(manager, contains('jobs.joinAll()'));
+    expect(cancellationCheck, greaterThan(0));
+    expect(planChange, greaterThan(cancellationCheck));
+    expect(
+      manager,
+      contains('suspend fun stopAll() = withBatchProbesStopped'),
+    );
+    expect(
+      manager,
+      contains('suspend fun applyPlan(planJson: String): String =\n'
+          '        withBatchProbesStopped'),
+    );
+  });
+
   test('optional checks are one non-blocking job per plan generation', () {
     expect(manager, contains('optionalCheckJob?.cancelAndJoin()'));
     expect(manager, contains('optionalCheckJob = GlobalState.scope.launch'));

--- a/test/product/runtime/built_in_proxy_supervisor_test.dart
+++ b/test/product/runtime/built_in_proxy_supervisor_test.dart
@@ -161,6 +161,32 @@ void main() {
       );
     });
 
+    test('serializes background activation of multiple ByeDPI nodes', () async {
+      var elapsed = Duration.zero;
+      runtime.onBatch = () => elapsed += const Duration(seconds: 1);
+      final supervisor = buildSupervisor(
+        byedpiStrategies: '--strategy 1\n--strategy 2',
+        monotonicNow: () => elapsed,
+      );
+      final plans = [
+        _byedpiAutoPlan(),
+        _byedpiAutoPlan(nodeId: 'byedpi-auto-b', port: 35112),
+      ];
+      expect(await supervisor.stageRuntimePlan(plans), isEmpty);
+      expect((await supervisor.startRuntimePlan(plans)).isSuccess, isTrue);
+      runtime
+        ..batchResults.addAll([0, 0])
+        ..applyGate = Completer<void>();
+
+      await supervisor.commitStagedRuntimePlan(plans);
+      await _waitUntil(() => runtime.activeApplyCalls == 1);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(runtime.maximumActiveApplyCalls, 1);
+      runtime.applyGate!.complete();
+      await _waitUntil(() => runtime.appliedPlans.length == 3);
+    });
+
     test('does not apply a background strategy after a new plan is staged',
         () async {
       var elapsed = Duration.zero;
@@ -242,18 +268,22 @@ BuiltInProxyNodePlan _byedpiPlan() => BuiltInProxyNodePlan(
       },
     );
 
-BuiltInProxyNodePlan _byedpiAutoPlan() => BuiltInProxyNodePlan(
-      nodeId: 'byedpi-auto',
+BuiltInProxyNodePlan _byedpiAutoPlan({
+  String nodeId = 'byedpi-auto',
+  int port = 35111,
+}) =>
+    BuiltInProxyNodePlan(
+      nodeId: nodeId,
       name: 'ByeDPI Auto',
       type: BuiltInProxyType.byedpi,
       listenHost: '127.0.0.1',
-      listenPort: 35111,
+      listenPort: port,
       protocol: BuiltInProxyProtocol.socks5,
       udp: false,
       files: {
-        'built-in-proxies/byedpi/byedpi-auto/config.json': json.encode({
+        'built-in-proxies/byedpi/$nodeId/config.json': json.encode({
           'listenHost': '127.0.0.1',
-          'listenPort': 35111,
+          'listenPort': port,
           'mode': 'auto',
           'strategyList': 'byebyeedpi',
           'strategyTest': {
@@ -358,28 +388,40 @@ class _FakeRuntimeNodeBridge
   final List<int?> batchResults = [];
   int generation = 0;
   int allocatedPorts = 0;
+  int activeApplyCalls = 0;
+  int maximumActiveApplyCalls = 0;
   String? savedManifest;
   void Function()? onBatch;
+  Completer<void>? applyGate;
 
   @override
   Future<RuntimeNodePlanState> applyPlan(
     List<Map<String, dynamic>> nodes,
   ) async {
-    final snapshot = [
-      for (final node in nodes) Map<String, dynamic>.from(node)
-    ];
-    if (appliedPlans.isEmpty ||
-        appliedPlans.last.toString() != snapshot.toString()) {
-      generation++;
+    activeApplyCalls++;
+    if (activeApplyCalls > maximumActiveApplyCalls) {
+      maximumActiveApplyCalls = activeApplyCalls;
     }
-    appliedPlans.add(snapshot);
-    return RuntimeNodePlanState(
-      generation: generation,
-      status: nodes.isEmpty ? 'idle' : 'ready',
-      message: '',
-      nodes: snapshot,
-      optionalCheckActive: false,
-    );
+    try {
+      await applyGate?.future;
+      final snapshot = [
+        for (final node in nodes) Map<String, dynamic>.from(node)
+      ];
+      if (appliedPlans.isEmpty ||
+          appliedPlans.last.toString() != snapshot.toString()) {
+        generation++;
+      }
+      appliedPlans.add(snapshot);
+      return RuntimeNodePlanState(
+        generation: generation,
+        status: nodes.isEmpty ? 'idle' : 'ready',
+        message: '',
+        nodes: snapshot,
+        optionalCheckActive: false,
+      );
+    } finally {
+      activeApplyCalls--;
+    }
   }
 
   @override

--- a/test/product/runtime/byedpi_node_controller_test.dart
+++ b/test/product/runtime/byedpi_node_controller_test.dart
@@ -392,10 +392,10 @@ void main() {
         },
       );
       await Future<void>.delayed(Duration.zero);
-      controller.cancelBackgroundSelection();
+      final cancellation = controller.cancelBackgroundSelection();
       runtime.batchGate!.complete(0);
       await runtime.batchFinished!.future.timeout(const Duration(seconds: 1));
-      await Future<void>.delayed(Duration.zero);
+      await cancellation;
 
       expect(activationCalls, 0);
       expect(json.decode(await cache.readAsString()), provisional);
@@ -414,7 +414,7 @@ void main() {
       final legacyCache = json.decode(await cache.readAsString()) as Map
         ..remove('selectionRevision');
       await cache.writeAsString(json.encode(legacyCache), flush: true);
-      controller.cancelBackgroundSelection();
+      await controller.cancelBackgroundSelection();
       runtime.batchResults.add(0);
 
       final node = (await controller.buildRuntimeNodes([plan])).single;


### PR DESCRIPTION
## Что изменено
- Android plan transitions регистрируют, отменяют и дожидаются batch-probe без удержания plan lock
- фоновые активации нескольких ByeDPI-узлов выполняются последовательно и завершаются перед staging/stop
- атомарная запись strategy cache больше не удаляет рабочий файл при ошибке rename
- отменённый Android transition проверяет cancellation перед изменением процессов

## Проверка
- `nix develop --command make check` — 239 тестов, analyzer и guards passed
- lifecycle contract test — 9/9 passed
- timing-sensitive ByeDPI suites — 3 последовательных прогона passed
- `flutter build apk --debug --target-platform android-arm64` — passed
- независимый fail-closed review — passed без замечаний