### PR TITLE
feat: add strict built-in node validation

### DIFF
--- a/lib/product/compile/built_in_proxy_compiler.dart
+++ b/lib/product/compile/built_in_proxy_compiler.dart
@@ -7,7 +7,9 @@ import 'package:flclashx/product/runtime/built_in_proxy_types.dart';
 import 'package:flclashx/product/runtime/connectivity_check.dart';
 import 'package:flutter/foundation.dart';
 
+import 'byedpi_config_validator.dart';
 import 'config_tree.dart';
+import 'naiveproxy_config_validator.dart';
 import 'olcrtc_config_validator.dart';
 
 @immutable
@@ -23,11 +25,32 @@ const _defaultByedpiStrategyTestUrl = 'https://youtube.com/generate_204';
 class BuiltInProxyCompiler {
   const BuiltInProxyCompiler({
     this.registry = builtInProxyRegistry,
+    this.naiveProxyConfigValidator = const NaiveProxyConfigValidator(),
+    this.byedpiConfigValidator = const ByedpiConfigValidator(),
     this.olcRtcConfigValidator = const OlcRtcConfigValidator(),
   });
 
   final BuiltInProxyRegistry registry;
+  final NaiveProxyConfigValidator naiveProxyConfigValidator;
+  final ByedpiConfigValidator byedpiConfigValidator;
   final OlcRtcConfigValidator olcRtcConfigValidator;
+
+  void validateConfig(Map<String, dynamic> rawConfig) {
+    _rejectLegacyRuntimeSelection(rawConfig);
+    final proxyEntries = rawConfig['proxies'];
+    if (proxyEntries is! List) {
+      return;
+    }
+    for (final proxy in proxyEntries) {
+      if (proxy is! Map) {
+        continue;
+      }
+      final definition = _parseBuiltInProxyNode(proxy);
+      if (definition != null) {
+        _validateDefinition(definition);
+      }
+    }
+  }
 
   CompiledBuiltInProxyNodes compile({
     required Map<String, dynamic> rawConfig,
@@ -37,7 +60,7 @@ class BuiltInProxyCompiler {
     final normalizedConfig = copyConfigTree(rawConfig);
     final proxyEntries = normalizedConfig['proxies'];
     if (proxyEntries is! List) {
-      _rejectLegacyRuntimeSelection(normalizedConfig);
+      validateConfig(normalizedConfig);
       normalizedConfig.remove('x-flclashm-runtime');
       return CompiledBuiltInProxyNodes(
         config: normalizedConfig,
@@ -45,7 +68,7 @@ class BuiltInProxyCompiler {
       );
     }
 
-    _rejectLegacyRuntimeSelection(normalizedConfig);
+    validateConfig(normalizedConfig);
     normalizedConfig.remove('x-flclashm-runtime');
 
     final reservedPorts = _collectReservedPorts(
@@ -92,6 +115,17 @@ class BuiltInProxyCompiler {
       config: normalizedConfig,
       nodes: compiledNodes,
     );
+  }
+
+  void _validateDefinition(BuiltInProxyNodeDefinition definition) {
+    switch (definition.type) {
+      case BuiltInProxyType.naiveproxy:
+        naiveProxyConfigValidator.validate(definition.rawConfig);
+      case BuiltInProxyType.byedpi:
+        byedpiConfigValidator.validate(definition.rawConfig);
+      case BuiltInProxyType.olcrtc:
+        olcRtcConfigValidator.validateBuiltInNode(definition.rawConfig);
+    }
   }
 
   BuiltInProxyNodeDefinition? _parseBuiltInProxyNode(dynamic proxy) {
@@ -195,12 +229,7 @@ class BuiltInProxyCompiler {
       );
     }
 
-    final proxy = _trimmedString(rawConfig['proxy']);
-    if (proxy == null) {
-      throw const FormatException(
-        'naiveproxy built-in nodes require a non-empty `proxy` field.',
-      );
-    }
+    final proxy = rawConfig['proxy'];
 
     return BuiltInProxyNodePlan(
       nodeId: nodeId,

--- a/lib/product/compile/built_in_proxy_schema.dart
+++ b/lib/product/compile/built_in_proxy_schema.dart
@@ -1,0 +1,815 @@
+import 'package:flutter/foundation.dart';
+
+import '../runtime/built_in_proxy_types.dart';
+import '../runtime/byedpi_release.dart';
+import '../runtime/naiveproxy_release.dart';
+import '../runtime/olcrtc_release.dart';
+
+enum ConfigValueType { string, boolean, integer, number, object, list }
+
+@immutable
+class ConfigValueRange {
+  const ConfigValueRange({
+    this.minimum,
+    this.maximum,
+    this.exclusiveMinimum = false,
+  });
+
+  final num? minimum;
+  final num? maximum;
+  final bool exclusiveMinimum;
+}
+
+@immutable
+class ConfigDefaultValue {
+  const ConfigDefaultValue.absent()
+      : isSpecified = false,
+        value = null;
+
+  const ConfigDefaultValue.of(this.value) : isSpecified = true;
+
+  final bool isSpecified;
+  final Object? value;
+}
+
+@immutable
+class BuiltInProxyFieldSchema {
+  const BuiltInProxyFieldSchema({
+    required this.path,
+    required this.type,
+    this.additionalTypes = const <ConfigValueType>{},
+    this.required = false,
+    this.modes = const <String>{},
+    this.allowedValues = const <Object>{},
+    this.range = const ConfigValueRange(),
+    this.defaultValue = const ConfigDefaultValue.absent(),
+    this.forbiddenReason,
+  });
+
+  final String path;
+  final ConfigValueType type;
+  final Set<ConfigValueType> additionalTypes;
+  final bool required;
+  final Set<String> modes;
+  final Set<Object> allowedValues;
+  final ConfigValueRange range;
+  final ConfigDefaultValue defaultValue;
+  final String? forbiddenReason;
+}
+
+@immutable
+class BuiltInProxySchema {
+  const BuiltInProxySchema({
+    required this.type,
+    required this.runtimeVersion,
+    required this.fields,
+  });
+
+  final BuiltInProxyType type;
+  final String runtimeVersion;
+  final List<BuiltInProxyFieldSchema> fields;
+}
+
+const _commonFields = <BuiltInProxyFieldSchema>[
+  BuiltInProxyFieldSchema(
+    path: 'common.name',
+    type: ConfigValueType.string,
+    required: true,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.type',
+    type: ConfigValueType.string,
+    required: true,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.udp',
+    type: ConfigValueType.boolean,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check',
+    type: ConfigValueType.object,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.urls',
+    type: ConfigValueType.list,
+    defaultValue: ConfigDefaultValue.of(<String>[]),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.urls[]',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.required',
+    type: ConfigValueType.boolean,
+    defaultValue: ConfigDefaultValue.of(false),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.timeout',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 60),
+    defaultValue: ConfigDefaultValue.of(5),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.startup-timeout',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 300),
+    defaultValue: ConfigDefaultValue.of(30),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.retry-interval',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 300),
+    defaultValue: ConfigDefaultValue.of(1),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.requests',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 32),
+    defaultValue: ConfigDefaultValue.of(1),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.concurrency',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 16),
+    defaultValue: ConfigDefaultValue.of(1),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'common.connectivity-check.min-success-ratio',
+    type: ConfigValueType.number,
+    range: ConfigValueRange(
+      minimum: 0,
+      maximum: 1,
+      exclusiveMinimum: true,
+    ),
+  ),
+];
+
+List<BuiltInProxyFieldSchema> _forType(
+  String type,
+  List<BuiltInProxyFieldSchema> fields,
+) =>
+    <BuiltInProxyFieldSchema>[
+      for (final field in _commonFields)
+        BuiltInProxyFieldSchema(
+          path: field.path.replaceFirst('common', type),
+          type: field.type,
+          additionalTypes: field.additionalTypes,
+          required: field.required,
+          modes: field.modes,
+          allowedValues: field.path == 'common.type'
+              ? <Object>{type}
+              : field.allowedValues,
+          range: field.range,
+          defaultValue: field.defaultValue,
+          forbiddenReason: field.forbiddenReason,
+        ),
+      ...fields,
+    ];
+
+final builtInProxySchemas = <BuiltInProxyType, BuiltInProxySchema>{
+  BuiltInProxyType.naiveproxy: BuiltInProxySchema(
+    type: BuiltInProxyType.naiveproxy,
+    runtimeVersion: naiveProxyPinnedReleaseTag,
+    fields: _forType('naiveproxy', const <BuiltInProxyFieldSchema>[
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.proxy',
+        type: ConfigValueType.string,
+        additionalTypes: <ConfigValueType>{ConfigValueType.list},
+        required: true,
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.proxy[]',
+        type: ConfigValueType.string,
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.insecure-concurrency',
+        type: ConfigValueType.integer,
+        additionalTypes: <ConfigValueType>{ConfigValueType.string},
+        range: ConfigValueRange(minimum: 1, maximum: 4),
+        defaultValue: ConfigDefaultValue.of(1),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.tunnel-timeout',
+        type: ConfigValueType.integer,
+        additionalTypes: <ConfigValueType>{ConfigValueType.string},
+        range: ConfigValueRange(minimum: 1, maximum: 2147483647),
+        defaultValue: ConfigDefaultValue.of(600),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.idle-timeout',
+        type: ConfigValueType.integer,
+        additionalTypes: <ConfigValueType>{ConfigValueType.string},
+        range: ConfigValueRange(minimum: 1, maximum: 2147483647),
+        defaultValue: ConfigDefaultValue.of(300),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.extra-headers',
+        type: ConfigValueType.string,
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.host-resolver-rules',
+        type: ConfigValueType.string,
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.resolver-range',
+        type: ConfigValueType.string,
+        defaultValue: ConfigDefaultValue.of('100.64.0.0/10'),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.no-post-quantum',
+        type: ConfigValueType.boolean,
+        forbiddenReason: 'post-quantum key agreement cannot be disabled',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.listen',
+        type: ConfigValueType.string,
+        forbiddenReason: 'the local listener is owned by FlClashM',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.server',
+        type: ConfigValueType.string,
+        forbiddenReason:
+            'the runtime endpoint is owned by FlClashM and derived from proxy',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.port',
+        type: ConfigValueType.integer,
+        forbiddenReason: 'the local listener port is owned by FlClashM',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.log',
+        type: ConfigValueType.string,
+        forbiddenReason: 'user-selected output paths are not supported',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.log-net-log',
+        type: ConfigValueType.string,
+        forbiddenReason: 'user-selected output paths are not supported',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'naiveproxy.ssl-key-log-file',
+        type: ConfigValueType.string,
+        forbiddenReason: 'TLS key logging is not supported',
+      ),
+    ]),
+  ),
+  BuiltInProxyType.byedpi: BuiltInProxySchema(
+    type: BuiltInProxyType.byedpi,
+    runtimeVersion: byedpiPinnedReleaseTag,
+    fields: _forType('byedpi', const <BuiltInProxyFieldSchema>[
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.mode',
+        type: ConfigValueType.string,
+        allowedValues: <Object>{'manual', 'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.args',
+        type: ConfigValueType.string,
+        required: true,
+        modes: <String>{'manual'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategies',
+        type: ConfigValueType.list,
+        modes: <String>{'auto'},
+        defaultValue: ConfigDefaultValue.of(<String>[]),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategies[]',
+        type: ConfigValueType.string,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-list',
+        type: ConfigValueType.string,
+        modes: <String>{'auto'},
+        allowedValues: <Object>{'byebyeedpi'},
+        defaultValue: ConfigDefaultValue.of('byebyeedpi'),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test',
+        type: ConfigValueType.object,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.urls',
+        type: ConfigValueType.list,
+        modes: <String>{'auto'},
+        defaultValue:
+            ConfigDefaultValue.of(<String>['https://youtube.com/generate_204']),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.urls[]',
+        type: ConfigValueType.string,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.sni',
+        type: ConfigValueType.string,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.timeout',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 60),
+        defaultValue: ConfigDefaultValue.of(5),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.requests',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 32),
+        defaultValue: ConfigDefaultValue.of(1),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.concurrency',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 16),
+        defaultValue: ConfigDefaultValue.of(4),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.strategy-test.min-success-ratio',
+        type: ConfigValueType.number,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(
+          minimum: 0,
+          maximum: 1,
+          exclusiveMinimum: true,
+        ),
+        defaultValue: ConfigDefaultValue.of(1.0),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.selection',
+        type: ConfigValueType.object,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.selection.concurrency',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 16),
+        defaultValue: ConfigDefaultValue.of(4),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.selection.foreground-timeout',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 60),
+        defaultValue: ConfigDefaultValue.of(15),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.selection.background',
+        type: ConfigValueType.boolean,
+        modes: <String>{'auto'},
+        defaultValue: ConfigDefaultValue.of(true),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.fallback-args',
+        type: ConfigValueType.string,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.cache',
+        type: ConfigValueType.object,
+        modes: <String>{'auto'},
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.cache.ttl',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 31536000),
+        defaultValue: ConfigDefaultValue.of(604800),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.cache.recheck-after',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 31536000),
+        defaultValue: ConfigDefaultValue.of(86400),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.cache.retry-after',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 31536000),
+        defaultValue: ConfigDefaultValue.of(300),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.cache.failure-threshold',
+        type: ConfigValueType.integer,
+        modes: <String>{'auto'},
+        range: ConfigValueRange(minimum: 1, maximum: 32),
+        defaultValue: ConfigDefaultValue.of(2),
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.test',
+        type: ConfigValueType.object,
+        forbiddenReason: 'rename it to strategy-test',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.listen',
+        type: ConfigValueType.string,
+        forbiddenReason: 'the local listener is owned by FlClashM',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.server',
+        type: ConfigValueType.string,
+        forbiddenReason: 'the local listener is owned by FlClashM',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.ip',
+        type: ConfigValueType.string,
+        forbiddenReason: 'the local listener address is owned by FlClashM',
+      ),
+      BuiltInProxyFieldSchema(
+        path: 'byedpi.port',
+        type: ConfigValueType.integer,
+        forbiddenReason: 'the local listener port is owned by FlClashM',
+      ),
+    ]),
+  ),
+  BuiltInProxyType.olcrtc: BuiltInProxySchema(
+    type: BuiltInProxyType.olcrtc,
+    runtimeVersion: olcRtcPinnedReleaseTag,
+    fields: _forType('olcrtc', _olcRtcFields),
+  ),
+};
+
+final _olcRtcFields = <BuiltInProxyFieldSchema>[
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.mode',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{'cnc'},
+    defaultValue: ConfigDefaultValue.of('cnc'),
+  ),
+  const BuiltInProxyFieldSchema(
+      path: 'olcrtc.auth', type: ConfigValueType.object),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.auth.provider',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{'jitsi', 'telemost', 'wbstream', 'none'},
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.auth.token',
+    type: ConfigValueType.string,
+  ),
+  const BuiltInProxyFieldSchema(
+      path: 'olcrtc.room', type: ConfigValueType.object),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.room.id',
+    type: ConfigValueType.string,
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.room.channel',
+    type: ConfigValueType.string,
+  ),
+  const BuiltInProxyFieldSchema(
+      path: 'olcrtc.crypto', type: ConfigValueType.object),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.crypto.key',
+    type: ConfigValueType.string,
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.crypto.key_file',
+    type: ConfigValueType.string,
+    forbiddenReason: 'file-backed secrets are not supported',
+  ),
+  const BuiltInProxyFieldSchema(
+      path: 'olcrtc.net', type: ConfigValueType.object),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.net.transport',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{
+      'datachannel',
+      'videochannel',
+      'seichannel',
+      'vp8channel',
+    },
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.net.dns',
+    type: ConfigValueType.string,
+  ),
+  ..._olcRtcSocksFields,
+  ..._olcRtcEngineFields,
+  ..._olcRtcTransportFields,
+  ..._olcRtcLifecycleFields,
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.profiles',
+    type: ConfigValueType.list,
+    defaultValue: ConfigDefaultValue.of(<Object>[]),
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.profiles[]',
+    type: ConfigValueType.object,
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.profiles[].name',
+    type: ConfigValueType.string,
+  ),
+  ..._olcRtcProfileFields,
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.failover',
+    type: ConfigValueType.object,
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.failover.retry_delay',
+    type: ConfigValueType.string,
+    defaultValue: ConfigDefaultValue.of('2s'),
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.failover.max_cycles',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(0),
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.debug',
+    type: ConfigValueType.boolean,
+    defaultValue: ConfigDefaultValue.of(false),
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.data',
+    type: ConfigValueType.string,
+    forbiddenReason: 'the runtime data directory is owned by FlClashM',
+  ),
+  const BuiltInProxyFieldSchema(
+    path: 'olcrtc.gen',
+    type: ConfigValueType.object,
+    forbiddenReason: 'generation mode is not supported',
+  ),
+];
+
+const _olcRtcSocksFields = <BuiltInProxyFieldSchema>[
+  BuiltInProxyFieldSchema(path: 'olcrtc.socks', type: ConfigValueType.object),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.host',
+    type: ConfigValueType.string,
+    forbiddenReason: 'the local listener address is owned by FlClashM',
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.port',
+    type: ConfigValueType.integer,
+    forbiddenReason: 'the local listener port is owned by FlClashM',
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.user',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.pass',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.proxy_addr',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.proxy_port',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1, maximum: 65535),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.proxy_user',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.socks.proxy_pass',
+    type: ConfigValueType.string,
+  ),
+];
+
+const _olcRtcEngineFields = <BuiltInProxyFieldSchema>[
+  BuiltInProxyFieldSchema(path: 'olcrtc.engine', type: ConfigValueType.object),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.engine.name',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{'livekit', 'goolom', 'jitsi'},
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.engine.url',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.engine.token',
+    type: ConfigValueType.string,
+  ),
+];
+
+const _olcRtcTransportFields = <BuiltInProxyFieldSchema>[
+  BuiltInProxyFieldSchema(path: 'olcrtc.video', type: ConfigValueType.object),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.width',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(1920),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.height',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(1080),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.fps',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(30),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.bitrate',
+    type: ConfigValueType.string,
+    defaultValue: ConfigDefaultValue.of('2M'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.hw',
+    type: ConfigValueType.string,
+    defaultValue: ConfigDefaultValue.of('none'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.qr_size',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(256),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.qr_recovery',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{'low', 'medium', 'quartile', 'high', 'highest'},
+    defaultValue: ConfigDefaultValue.of('low'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.codec',
+    type: ConfigValueType.string,
+    allowedValues: <Object>{'qrcode', 'tile'},
+    defaultValue: ConfigDefaultValue.of('qrcode'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.tile_module',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(4),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.video.tile_rs',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(20),
+  ),
+  BuiltInProxyFieldSchema(path: 'olcrtc.vp8', type: ConfigValueType.object),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.vp8.fps',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(30),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.vp8.batch_size',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(64),
+  ),
+  BuiltInProxyFieldSchema(path: 'olcrtc.sei', type: ConfigValueType.object),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.sei.fps',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(30),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.sei.batch_size',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(64),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.sei.fragment_size',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(900),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.sei.ack_timeout_ms',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 1),
+    defaultValue: ConfigDefaultValue.of(2000),
+  ),
+];
+
+const _olcRtcLifecycleFields = <BuiltInProxyFieldSchema>[
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.liveness',
+    type: ConfigValueType.object,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.liveness.interval',
+    type: ConfigValueType.string,
+    defaultValue: ConfigDefaultValue.of('10s'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.liveness.timeout',
+    type: ConfigValueType.string,
+    defaultValue: ConfigDefaultValue.of('15s'),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.liveness.failures',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(4),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.lifecycle',
+    type: ConfigValueType.object,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.lifecycle.max_session_duration',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.traffic',
+    type: ConfigValueType.object,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.traffic.max_payload_size',
+    type: ConfigValueType.integer,
+    range: ConfigValueRange(minimum: 0),
+    defaultValue: ConfigDefaultValue.of(0),
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.traffic.min_delay',
+    type: ConfigValueType.string,
+  ),
+  BuiltInProxyFieldSchema(
+    path: 'olcrtc.traffic.max_delay',
+    type: ConfigValueType.string,
+  ),
+];
+
+final _olcRtcProfileFields = <BuiltInProxyFieldSchema>[
+  for (final field in <BuiltInProxyFieldSchema>[
+    ..._olcRtcSocksFields,
+    ..._olcRtcEngineFields,
+    ..._olcRtcTransportFields,
+    ..._olcRtcLifecycleFields,
+    const BuiltInProxyFieldSchema(
+        path: 'olcrtc.auth', type: ConfigValueType.object),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.auth.provider',
+      type: ConfigValueType.string,
+      allowedValues: <Object>{'jitsi', 'telemost', 'wbstream', 'none'},
+    ),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.auth.token',
+      type: ConfigValueType.string,
+    ),
+    const BuiltInProxyFieldSchema(
+        path: 'olcrtc.room', type: ConfigValueType.object),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.room.id',
+      type: ConfigValueType.string,
+    ),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.room.channel',
+      type: ConfigValueType.string,
+    ),
+    const BuiltInProxyFieldSchema(
+        path: 'olcrtc.crypto', type: ConfigValueType.object),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.crypto.key',
+      type: ConfigValueType.string,
+    ),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.crypto.key_file',
+      type: ConfigValueType.string,
+      forbiddenReason: 'file-backed secrets are not supported',
+    ),
+    const BuiltInProxyFieldSchema(
+        path: 'olcrtc.net', type: ConfigValueType.object),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.net.transport',
+      type: ConfigValueType.string,
+      allowedValues: <Object>{
+        'datachannel',
+        'videochannel',
+        'seichannel',
+        'vp8channel',
+      },
+    ),
+    const BuiltInProxyFieldSchema(
+      path: 'olcrtc.net.dns',
+      type: ConfigValueType.string,
+    ),
+  ])
+    BuiltInProxyFieldSchema(
+      path: field.path.replaceFirst('olcrtc.', 'olcrtc.profiles[].'),
+      type: field.type,
+      required: field.required,
+      modes: field.modes,
+      allowedValues: field.allowedValues,
+      range: field.range,
+      defaultValue: field.defaultValue,
+      forbiddenReason: field.forbiddenReason,
+    ),
+];

--- a/lib/product/compile/byedpi_cli_validator.dart
+++ b/lib/product/compile/byedpi_cli_validator.dart
@@ -1,0 +1,720 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+enum ByedpiCliContext { args, strategy, fallbackArgs }
+
+enum ByedpiCliValueKind {
+  none,
+  text,
+  address,
+  bufferSize,
+  connectionLimit,
+  debugLevel,
+  positiveInteger,
+  nonNegativeInteger,
+  uint8,
+  timeout,
+  autoDetect,
+  autoMode,
+  inlineData,
+  protocolList,
+  portRange,
+  positiveRange,
+  position,
+  tlsRecordPosition,
+  fakeTlsModifiers,
+  escapedCharacter,
+  httpModifiers,
+}
+
+enum ByedpiCliScope { process, group, groupSeparator }
+
+@immutable
+class ByedpiCliOptionSchema {
+  const ByedpiCliOptionSchema({
+    required this.shortName,
+    required this.longName,
+    required this.valueKind,
+    this.repeatable = false,
+    this.contexts = const <ByedpiCliContext>{
+      ByedpiCliContext.args,
+      ByedpiCliContext.strategy,
+      ByedpiCliContext.fallbackArgs,
+    },
+    this.scope = ByedpiCliScope.group,
+    this.forbiddenReason,
+  });
+
+  final String shortName;
+  final String longName;
+  final ByedpiCliValueKind valueKind;
+  final bool repeatable;
+  final Set<ByedpiCliContext> contexts;
+  final ByedpiCliScope scope;
+  final String? forbiddenReason;
+
+  bool get takesValue => valueKind != ByedpiCliValueKind.none;
+}
+
+@immutable
+class ValidatedByedpiCliOption {
+  const ValidatedByedpiCliOption({
+    required this.name,
+    required this.value,
+  });
+
+  final String name;
+  final String? value;
+}
+
+@immutable
+class ByedpiCliValidationResult {
+  const ByedpiCliValidationResult({
+    required this.arguments,
+    required this.options,
+  });
+
+  final List<String> arguments;
+  final List<ValidatedByedpiCliOption> options;
+}
+
+const byedpiCliOptions = <ByedpiCliOptionSchema>[
+  ByedpiCliOptionSchema(
+    shortName: 'N',
+    longName: 'no-domain',
+    valueKind: ByedpiCliValueKind.none,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'DNS behavior is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'U',
+    longName: 'no-udp',
+    valueKind: ByedpiCliValueKind.none,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'UDP behavior is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'I',
+    longName: 'conn-ip',
+    valueKind: ByedpiCliValueKind.address,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'the outbound bind address is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'b',
+    longName: 'buf-size',
+    valueKind: ByedpiCliValueKind.bufferSize,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'process resource limits are owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'c',
+    longName: 'max-conn',
+    valueKind: ByedpiCliValueKind.connectionLimit,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'process resource limits are owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'x',
+    longName: 'debug',
+    valueKind: ByedpiCliValueKind.debugLevel,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'runtime logging is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'F',
+    longName: 'tfo',
+    valueKind: ByedpiCliValueKind.none,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'process networking is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'T',
+    longName: 'timeout',
+    valueKind: ByedpiCliValueKind.timeout,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'process timeouts are owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'g',
+    longName: 'def-ttl',
+    valueKind: ByedpiCliValueKind.uint8,
+    scope: ByedpiCliScope.process,
+    forbiddenReason: 'process networking is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'A',
+    longName: 'auto',
+    valueKind: ByedpiCliValueKind.autoDetect,
+    repeatable: true,
+    scope: ByedpiCliScope.groupSeparator,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'L',
+    longName: 'auto-mode',
+    valueKind: ByedpiCliValueKind.autoMode,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'u',
+    longName: 'cache-ttl',
+    valueKind: ByedpiCliValueKind.positiveInteger,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'K',
+    longName: 'proto',
+    valueKind: ByedpiCliValueKind.protocolList,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'H',
+    longName: 'hosts',
+    valueKind: ByedpiCliValueKind.inlineData,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'j',
+    longName: 'ipset',
+    valueKind: ByedpiCliValueKind.inlineData,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'V',
+    longName: 'pf',
+    valueKind: ByedpiCliValueKind.portRange,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'R',
+    longName: 'round',
+    valueKind: ByedpiCliValueKind.positiveRange,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 's',
+    longName: 'split',
+    valueKind: ByedpiCliValueKind.position,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'd',
+    longName: 'disorder',
+    valueKind: ByedpiCliValueKind.position,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'o',
+    longName: 'oob',
+    valueKind: ByedpiCliValueKind.position,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'q',
+    longName: 'disoob',
+    valueKind: ByedpiCliValueKind.position,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'f',
+    longName: 'fake',
+    valueKind: ByedpiCliValueKind.position,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'S',
+    longName: 'md5sig',
+    valueKind: ByedpiCliValueKind.none,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'n',
+    longName: 'fake-sni',
+    valueKind: ByedpiCliValueKind.text,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 't',
+    longName: 'ttl',
+    valueKind: ByedpiCliValueKind.uint8,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'l',
+    longName: 'fake-data',
+    valueKind: ByedpiCliValueKind.inlineData,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'O',
+    longName: 'fake-offset',
+    valueKind: ByedpiCliValueKind.position,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'Q',
+    longName: 'fake-tls-mod',
+    valueKind: ByedpiCliValueKind.fakeTlsModifiers,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'e',
+    longName: 'oob-data',
+    valueKind: ByedpiCliValueKind.escapedCharacter,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'M',
+    longName: 'mod-http',
+    valueKind: ByedpiCliValueKind.httpModifiers,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'r',
+    longName: 'tlsrec',
+    valueKind: ByedpiCliValueKind.tlsRecordPosition,
+    repeatable: true,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'm',
+    longName: 'tlsminor',
+    valueKind: ByedpiCliValueKind.uint8,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'a',
+    longName: 'udp-fake',
+    valueKind: ByedpiCliValueKind.nonNegativeInteger,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'Y',
+    longName: 'drop-sack',
+    valueKind: ByedpiCliValueKind.none,
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'i',
+    longName: 'ip',
+    valueKind: ByedpiCliValueKind.address,
+    forbiddenReason: 'the listener address is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'p',
+    longName: 'port',
+    valueKind: ByedpiCliValueKind.positiveInteger,
+    forbiddenReason: 'the listener port is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'D',
+    longName: 'daemon',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'process lifecycle is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'w',
+    longName: 'pidfile',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'process lifecycle is owned by FlClashM',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'E',
+    longName: 'transparent',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'transparent mode bypasses the local SOCKS contract',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'P',
+    longName: 'protect-path',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'file delivery is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'y',
+    longName: 'cache-file',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'user-selected file paths are not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'B',
+    longName: 'copy',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'undocumented parser control is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'Z',
+    longName: 'wait-send',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'undocumented runtime control is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'W',
+    longName: 'await-int',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'undocumented runtime control is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'C',
+    longName: 'connect-to',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'undocumented outbound redirection is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: '#',
+    longName: 'comment',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'undocumented parser metadata is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: '/',
+    longName: 'cache-merge',
+    valueKind: ByedpiCliValueKind.text,
+    forbiddenReason: 'undocumented cache control is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'X',
+    longName: 'no-ipv6',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'undocumented network control is not supported',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'h',
+    longName: 'help',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'process control flags are not runtime arguments',
+  ),
+  ByedpiCliOptionSchema(
+    shortName: 'v',
+    longName: 'version',
+    valueKind: ByedpiCliValueKind.none,
+    forbiddenReason: 'process control flags are not runtime arguments',
+  ),
+];
+
+class ByedpiCliValidator {
+  const ByedpiCliValidator();
+
+  ByedpiCliValidationResult validate(
+    String source, {
+    required String path,
+    required ByedpiCliContext context,
+  }) {
+    final arguments = _splitShell(source, path);
+    if (arguments.isEmpty) {
+      throw FormatException('$path must contain at least one ByeDPI option.');
+    }
+    final byShort = <String, ByedpiCliOptionSchema>{
+      for (final option in byedpiCliOptions) option.shortName: option,
+    };
+    final byLong = <String, ByedpiCliOptionSchema>{
+      for (final option in byedpiCliOptions) option.longName: option,
+    };
+    final parsed = <ValidatedByedpiCliOption>[];
+    final seen = <String, int>{};
+    var group = 0;
+
+    void record(ByedpiCliOptionSchema option, String? value) {
+      if (option.forbiddenReason case final reason?) {
+        throw FormatException(
+          '$path: --${option.longName} is forbidden: $reason.',
+        );
+      }
+      if (!option.contexts.contains(context)) {
+        throw FormatException(
+          '$path: --${option.longName} is not available in ${context.name}.',
+        );
+      }
+      _validateValue(option, value, path);
+      final scopeKey =
+          option.scope == ByedpiCliScope.process ? 'process' : group;
+      final occurrenceKey = '$scopeKey:${option.longName}';
+      final count = seen[occurrenceKey] ?? 0;
+      if (count > 0 && !option.repeatable) {
+        throw FormatException(
+          '$path: --${option.longName} must not be repeated in the same context.',
+        );
+      }
+      seen[occurrenceKey] = count + 1;
+      parsed.add(
+        ValidatedByedpiCliOption(name: option.longName, value: value),
+      );
+      if (option.scope == ByedpiCliScope.groupSeparator) {
+        group++;
+      }
+    }
+
+    for (var index = 0; index < arguments.length; index++) {
+      final argument = arguments[index];
+      if (argument.startsWith('--')) {
+        final separator = argument.indexOf('=');
+        final name = separator < 0
+            ? argument.substring(2)
+            : argument.substring(2, separator);
+        final option = byLong[name];
+        if (option == null) {
+          throw FormatException(
+            '$path: unknown ByeDPI option `--$name`${_suggest(name, byLong.keys)}.',
+          );
+        }
+        String? value;
+        if (option.takesValue) {
+          if (separator >= 0) {
+            value = argument.substring(separator + 1);
+          } else if (++index < arguments.length) {
+            value = arguments[index];
+          } else {
+            throw FormatException('$path: --$name requires a value.');
+          }
+        } else if (separator >= 0) {
+          throw FormatException('$path: --$name does not accept a value.');
+        }
+        record(option, value);
+        continue;
+      }
+      if (!argument.startsWith('-') || argument.length == 1) {
+        throw FormatException(
+          '$path: unexpected positional argument `$argument`.',
+        );
+      }
+
+      var offset = 1;
+      while (offset < argument.length) {
+        final name = argument[offset];
+        final option = byShort[name];
+        if (option == null) {
+          throw FormatException('$path: unknown ByeDPI option `-$name`.');
+        }
+        String? value;
+        if (option.takesValue) {
+          if (offset + 1 < argument.length) {
+            value = argument.substring(offset + 1);
+          } else if (++index < arguments.length) {
+            value = arguments[index];
+          } else {
+            throw FormatException('$path: -$name requires a value.');
+          }
+          offset = argument.length;
+        } else {
+          offset++;
+        }
+        record(option, value);
+      }
+    }
+
+    return ByedpiCliValidationResult(
+      arguments: List<String>.unmodifiable(arguments),
+      options: List<ValidatedByedpiCliOption>.unmodifiable(parsed),
+    );
+  }
+
+  void _validateValue(
+    ByedpiCliOptionSchema option,
+    String? value,
+    String path,
+  ) {
+    if (!option.takesValue) return;
+    if (value == null || value.isEmpty) {
+      throw FormatException('$path: --${option.longName} requires a value.');
+    }
+    final valid = switch (option.valueKind) {
+      ByedpiCliValueKind.none => true,
+      ByedpiCliValueKind.text => _plainText(value),
+      ByedpiCliValueKind.address => _address(value),
+      ByedpiCliValueKind.bufferSize => _integerRange(value, 1, 536870911),
+      ByedpiCliValueKind.connectionLimit => _integerRange(value, 1, 32766),
+      ByedpiCliValueKind.debugLevel => _integerRange(value, 0, 2),
+      ByedpiCliValueKind.positiveInteger => _integerRange(value, 1, 2147483647),
+      ByedpiCliValueKind.nonNegativeInteger =>
+        _integerRange(value, 0, 2147483647),
+      ByedpiCliValueKind.uint8 => _integerRange(value, 1, 255),
+      ByedpiCliValueKind.timeout => RegExp(
+          r'^\d+(?:\.\d+)?(?::\d+(?:\.\d+)?(?::\d+(?:\.\d+)?(?::\d+(?:\.\d+)?)?)?)?$',
+        ).hasMatch(value),
+      ByedpiCliValueKind.autoDetect => _enumList(
+          value,
+          const <String>{
+            't',
+            'r',
+            's',
+            'n',
+            'c',
+            'torst',
+            'redirect',
+            'ssl_err',
+            'none',
+            'conn',
+          },
+          allowPriority: true),
+      ByedpiCliValueKind.autoMode => _enumList(value, const <String>{
+          's',
+          'o',
+          'n',
+          'swop',
+          'onreconn',
+          'noreconn',
+        }),
+      ByedpiCliValueKind.inlineData =>
+        value.startsWith(':') && value.length > 1,
+      ByedpiCliValueKind.protocolList => _enumList(value, const <String>{
+          't',
+          'h',
+          'u',
+          'i',
+          'tls',
+          'http',
+          'udp',
+          'ipv4',
+        }),
+      ByedpiCliValueKind.portRange => _range(value, 1, 65535),
+      ByedpiCliValueKind.positiveRange => _range(value, 1, 2147483647),
+      ByedpiCliValueKind.position => _position(value),
+      ByedpiCliValueKind.tlsRecordPosition => _tlsRecordPosition(value),
+      ByedpiCliValueKind.fakeTlsModifiers => _fakeTlsModifiers(value),
+      ByedpiCliValueKind.escapedCharacter => _escapedCharacter(value),
+      ByedpiCliValueKind.httpModifiers => _enumList(value, const <String>{
+          'h',
+          'd',
+          'r',
+          'hcsmix',
+          'dcsmix',
+          'rmspace',
+        }),
+    };
+    if (!valid) {
+      final detail = option.valueKind == ByedpiCliValueKind.inlineData
+          ? ' requires an inline `:value`; file paths are not supported'
+          : ' has an invalid value `$value`';
+      throw FormatException('$path: --${option.longName}$detail.');
+    }
+  }
+
+  List<String> _splitShell(String value, String path) {
+    final args = <String>[];
+    final buffer = StringBuffer();
+    var quote = '';
+    var escape = false;
+    for (final rune in value.runes) {
+      final char = String.fromCharCode(rune);
+      if (escape) {
+        buffer.write(char);
+        escape = false;
+      } else if (char == r'\') {
+        escape = true;
+      } else if (quote.isNotEmpty) {
+        if (char == quote) {
+          quote = '';
+        } else {
+          buffer.write(char);
+        }
+      } else if (char == '"' || char == "'") {
+        quote = char;
+      } else if (char.trim().isEmpty) {
+        if (buffer.isNotEmpty) {
+          args.add(buffer.toString());
+          buffer.clear();
+        }
+      } else {
+        buffer.write(char);
+      }
+    }
+    if (quote.isNotEmpty) {
+      throw FormatException('$path contains an unterminated quote.');
+    }
+    if (escape) {
+      throw FormatException('$path ends with an incomplete escape.');
+    }
+    if (buffer.isNotEmpty) args.add(buffer.toString());
+    return args;
+  }
+
+  bool _plainText(String value) =>
+      value.isNotEmpty &&
+      value.codeUnits.every((unit) => unit >= 0x20 && unit != 0x7f);
+
+  bool _address(String value) {
+    if (value == 'localhost') return true;
+    final uri = Uri.tryParse('socket://$value');
+    return uri != null && uri.host.isNotEmpty && !uri.hasPort;
+  }
+
+  bool _integerRange(String value, int minimum, int maximum) {
+    final parsed = int.tryParse(value);
+    return parsed != null && parsed >= minimum && parsed <= maximum;
+  }
+
+  bool _range(String value, int minimum, int maximum) {
+    final match = RegExp(r'^(\d+)(?:-(\d+))?$').firstMatch(value);
+    if (match == null) return false;
+    final start = int.parse(match.group(1)!);
+    final end = int.parse(match.group(2) ?? match.group(1)!);
+    return start >= minimum && end >= start && end <= maximum;
+  }
+
+  bool _position(String value) => RegExp(
+        r'^-?(?:0[xX][0-9a-fA-F]+|0[0-7]+|\d+)(?::[1-9]\d*(?::\d+)?)?(?:\+[shn][shemrn]{0,2})?$',
+      ).hasMatch(value);
+
+  bool _tlsRecordPosition(String value) {
+    if (!_position(value)) return false;
+    final suffix = value.indexOf(RegExp(r'[:+]'));
+    final rawPosition = suffix < 0 ? value : value.substring(0, suffix);
+    final position = _parseBaseZeroInteger(rawPosition);
+    return position != null && position <= 0xffff;
+  }
+
+  int? _parseBaseZeroInteger(String value) {
+    final negative = value.startsWith('-');
+    final unsigned = negative ? value.substring(1) : value;
+    final radix = unsigned.startsWith(RegExp(r'0[xX]'))
+        ? 16
+        : unsigned.length > 1 && unsigned.startsWith('0')
+            ? 8
+            : 10;
+    final digits = radix == 16 ? unsigned.substring(2) : unsigned;
+    final parsed = int.tryParse(digits, radix: radix);
+    return parsed == null
+        ? null
+        : negative
+            ? -parsed
+            : parsed;
+  }
+
+  bool _enumList(
+    String value,
+    Set<String> allowed, {
+    bool allowPriority = false,
+  }) {
+    final parts = value.split(',');
+    return parts.isNotEmpty &&
+        parts.every((part) {
+          if (allowed.contains(part)) return true;
+          if (allowPriority && part.startsWith('p=')) {
+            return double.tryParse(part.substring(2)) != null;
+          }
+          return false;
+        });
+  }
+
+  bool _fakeTlsModifiers(String value) => value.split(',').every(
+        (part) =>
+            const <String>{'r', 'o', 'rand', 'orig'}.contains(part) ||
+            RegExp(r'^(?:m|msize)=\d+$').hasMatch(part),
+      );
+
+  bool _escapedCharacter(String value) =>
+      value.runes.length == 1 ||
+      RegExp(r'^\\(?:[rntrfbva\\]|x[0-9a-fA-F]{2}|[0-7]{1,3})$')
+          .hasMatch(value);
+
+  String _suggest(String value, Iterable<String> candidates) {
+    if (candidates.isEmpty) return '';
+    final nearest = candidates.reduce(
+      (best, candidate) => _distance(value, candidate) < _distance(value, best)
+          ? candidate
+          : best,
+    );
+    return '; did you mean `--$nearest`?';
+  }
+
+  int _distance(String left, String right) {
+    var previous = List<int>.generate(right.length + 1, (index) => index);
+    for (var i = 0; i < left.length; i++) {
+      final current = <int>[i + 1];
+      for (var j = 0; j < right.length; j++) {
+        current.add(
+          math.min(
+            math.min(current[j] + 1, previous[j + 1] + 1),
+            previous[j] + (left.codeUnitAt(i) == right.codeUnitAt(j) ? 0 : 1),
+          ),
+        );
+      }
+      previous = current;
+    }
+    return previous.last;
+  }
+}

--- a/lib/product/compile/byedpi_config_validator.dart
+++ b/lib/product/compile/byedpi_config_validator.dart
@@ -1,0 +1,93 @@
+import '../runtime/built_in_proxy_types.dart';
+import 'built_in_proxy_schema.dart';
+import 'byedpi_cli_validator.dart';
+import 'strict_config_schema_validator.dart';
+
+class ByedpiConfigValidator {
+  const ByedpiConfigValidator({
+    this.schemaValidator = const StrictConfigSchemaValidator(),
+    this.cliValidator = const ByedpiCliValidator(),
+  });
+
+  final StrictConfigSchemaValidator schemaValidator;
+  final ByedpiCliValidator cliValidator;
+
+  String resolveMode(Map<String, dynamic> config) {
+    final value = config['mode'];
+    if (value == null) {
+      return config.containsKey('args') ? 'manual' : 'auto';
+    }
+    if (value is! String || value.isEmpty || value != value.trim()) {
+      throw const FormatException(
+        'byedpi.mode must be `manual` or `auto`.',
+      );
+    }
+    return value;
+  }
+
+  String validate(Map<String, dynamic> config) {
+    final mode = resolveMode(config);
+    schemaValidator.validate(
+      config,
+      schema: builtInProxySchemas[BuiltInProxyType.byedpi]!,
+      mode: mode,
+    );
+    if (mode == 'manual') {
+      _requireNonEmptyString(config['args'], 'byedpi.args');
+      cliValidator.validate(
+        config['args'] as String,
+        path: 'byedpi.args',
+        context: ByedpiCliContext.args,
+      );
+    } else {
+      final strategies = config['strategies'];
+      if (strategies is List) {
+        for (var index = 0; index < strategies.length; index++) {
+          _requireNonEmptyString(
+            strategies[index],
+            'byedpi.strategies[$index]',
+          );
+          cliValidator.validate(
+            strategies[index] as String,
+            path: 'byedpi.strategies[$index]',
+            context: ByedpiCliContext.strategy,
+          );
+        }
+      }
+      final fallback = config['fallback-args'];
+      if (fallback != null) {
+        _requireNonEmptyString(fallback, 'byedpi.fallback-args');
+        cliValidator.validate(
+          fallback as String,
+          path: 'byedpi.fallback-args',
+          context: ByedpiCliContext.fallbackArgs,
+        );
+      }
+      final strategiesPresent = strategies is List && strategies.isNotEmpty;
+      if (strategiesPresent && config.containsKey('strategy-list')) {
+        throw const FormatException(
+          'byedpi.strategy-list cannot be combined with byedpi.strategies.',
+        );
+      }
+      final cache = config['cache'];
+      if (cache is Map) {
+        final ttl = cache['ttl'] ?? 604800;
+        final recheckAfter = cache['recheck-after'] ?? 86400;
+        if (ttl is int && recheckAfter is int && recheckAfter > ttl) {
+          throw const FormatException(
+            'byedpi.cache.recheck-after must not exceed byedpi.cache.ttl.',
+          );
+        }
+      }
+    }
+    return mode;
+  }
+
+  void _requireNonEmptyString(Object? value, String path) {
+    if (value is! String || value.isEmpty || value != value.trim()) {
+      throw FormatException(
+        '$path must be a non-empty string without surrounding whitespace.',
+      );
+    }
+  }
+}

--- a/lib/product/compile/naiveproxy_config_validator.dart
+++ b/lib/product/compile/naiveproxy_config_validator.dart
@@ -1,0 +1,166 @@
+import '../runtime/built_in_proxy_types.dart';
+import 'built_in_proxy_schema.dart';
+import 'strict_config_schema_validator.dart';
+
+class NaiveProxyConfigValidator {
+  const NaiveProxyConfigValidator({
+    this.schemaValidator = const StrictConfigSchemaValidator(),
+  });
+
+  final StrictConfigSchemaValidator schemaValidator;
+
+  void validate(Map<String, dynamic> config) {
+    schemaValidator.validate(
+      config,
+      schema: builtInProxySchemas[BuiltInProxyType.naiveproxy]!,
+    );
+    final rawProxy = config['proxy'];
+    final proxies = rawProxy is String
+        ? <String>[rawProxy]
+        : (rawProxy as List).cast<String>();
+    if (proxies.isEmpty) {
+      throw const FormatException(
+          'naiveproxy.proxy must not be an empty list.');
+    }
+    for (var index = 0; index < proxies.length; index++) {
+      final proxy = proxies[index];
+      final path =
+          rawProxy is String ? 'naiveproxy.proxy' : 'naiveproxy.proxy[$index]';
+      if (proxy.isEmpty || proxy != proxy.trim()) {
+        throw FormatException(
+          '$path must be a non-empty string without surrounding whitespace.',
+        );
+      }
+      _validateProxyChain(proxy, path);
+    }
+    _validatePositiveInteger(config, 'insecure-concurrency');
+    _validatePositiveInteger(config, 'tunnel-timeout');
+    _validatePositiveInteger(config, 'idle-timeout');
+    _validateOptionalText(config, 'extra-headers', allowCrlf: true);
+    _validateOptionalText(config, 'host-resolver-rules');
+    _validateResolverRange(config['resolver-range']);
+  }
+
+  void _validateProxyChain(String value, String path) {
+    final parts = value.split(',');
+    if (parts.any((part) => part.isEmpty)) {
+      throw FormatException(
+        '$path must contain a valid proxy URI or proxy chain.',
+      );
+    }
+    var sawTcpProxy = false;
+    var sawSocks = false;
+    for (final part in parts) {
+      final uri = Uri.tryParse(part);
+      if (uri == null ||
+          !uri.hasAuthority ||
+          uri.host.isEmpty ||
+          uri.path.isNotEmpty && uri.path != '/' ||
+          uri.hasQuery ||
+          uri.hasFragment) {
+        throw FormatException('$path contains invalid URI `$part`.');
+      }
+      if (uri.hasPort && (uri.port < 1 || uri.port > 65535)) {
+        throw FormatException('$path contains invalid port in `$part`.');
+      }
+      switch (uri.scheme) {
+        case 'quic':
+          if (sawTcpProxy) {
+            throw FormatException(
+              '$path cannot place a QUIC proxy after a TCP proxy.',
+            );
+          }
+          break;
+        case 'http':
+        case 'https':
+          sawTcpProxy = true;
+          break;
+        case 'socks':
+          sawTcpProxy = true;
+          sawSocks = true;
+          if (uri.userInfo.isNotEmpty) {
+            throw FormatException(
+              '$path does not support authenticated SOCKS proxies.',
+            );
+          }
+          break;
+        default:
+          throw FormatException(
+              '$path uses unsupported scheme `${uri.scheme}`.');
+      }
+    }
+    if (sawSocks && parts.length > 1) {
+      throw FormatException('$path does not support SOCKS proxies in a chain.');
+    }
+  }
+
+  void _validateOptionalText(
+    Map<String, dynamic> config,
+    String field, {
+    bool allowCrlf = false,
+  }) {
+    final value = config[field];
+    if (value == null) return;
+    final text = value as String;
+    if (text.isEmpty || text != text.trim()) {
+      throw FormatException('naiveproxy.$field must be a non-empty string.');
+    }
+    for (final unit in text.codeUnits) {
+      final allowedLineBreak = allowCrlf && (unit == 0x0a || unit == 0x0d);
+      if (!allowedLineBreak && (unit < 0x20 || unit == 0x7f)) {
+        throw FormatException(
+          'naiveproxy.$field contains a forbidden control character.',
+        );
+      }
+    }
+    if (allowCrlf) {
+      for (var index = 0; index < text.length; index++) {
+        final unit = text.codeUnitAt(index);
+        final isBareCr = unit == 0x0d &&
+            (index + 1 == text.length || text.codeUnitAt(index + 1) != 0x0a);
+        final isBareLf =
+            unit == 0x0a && (index == 0 || text.codeUnitAt(index - 1) != 0x0d);
+        if (isBareCr || isBareLf) {
+          throw const FormatException(
+            'naiveproxy.extra-headers must use CRLF line endings.',
+          );
+        }
+      }
+      for (final line in text.split('\r\n')) {
+        final separator = line.indexOf(':');
+        final name = separator < 0 ? '' : line.substring(0, separator);
+        if (!RegExp(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$").hasMatch(name)) {
+          throw const FormatException(
+            'naiveproxy.extra-headers must contain CRLF-separated `name: value` headers.',
+          );
+        }
+      }
+    }
+  }
+
+  void _validatePositiveInteger(Map<String, dynamic> config, String field) {
+    final value = config[field];
+    if (value == null || value is int) return;
+    final parsed = RegExp(r'^[1-9]\d*$').hasMatch(value as String)
+        ? int.tryParse(value)
+        : null;
+    final maximum = field == 'insecure-concurrency' ? 4 : 2147483647;
+    if (parsed == null || parsed > maximum) {
+      throw FormatException(
+        'naiveproxy.$field must be a decimal integer in 1..$maximum.',
+      );
+    }
+  }
+
+  void _validateResolverRange(Object? value) {
+    if (value == null) return;
+    final match = RegExp(r'^(\d{1,3}(?:\.\d{1,3}){3})/(\d|[12]\d|3[0-2])$')
+        .firstMatch(value as String);
+    if (match == null ||
+        match.group(1)!.split('.').map(int.parse).any((octet) => octet > 255)) {
+      throw const FormatException(
+        'naiveproxy.resolver-range must be a valid IPv4 CIDR.',
+      );
+    }
+  }
+}

--- a/lib/product/compile/olcrtc_config_validator.dart
+++ b/lib/product/compile/olcrtc_config_validator.dart
@@ -1,5 +1,13 @@
+import '../runtime/built_in_proxy_types.dart';
+import 'built_in_proxy_schema.dart';
+import 'strict_config_schema_validator.dart';
+
 class OlcRtcConfigValidator {
-  const OlcRtcConfigValidator();
+  const OlcRtcConfigValidator({
+    this.schemaValidator = const StrictConfigSchemaValidator(),
+  });
+
+  final StrictConfigSchemaValidator schemaValidator;
 
   static const supportedProviders = {
     'jitsi',
@@ -13,6 +21,20 @@ class OlcRtcConfigValidator {
     'seichannel',
     'videochannel',
   };
+
+  void validateBuiltInNode(Map<String, dynamic> config) {
+    final rawMode = config['mode'];
+    final mode = rawMode == null
+        ? 'cnc'
+        : rawMode is String
+            ? rawMode
+            : null;
+    schemaValidator.validate(
+      config,
+      schema: builtInProxySchemas[BuiltInProxyType.olcrtc]!,
+      mode: mode,
+    );
+  }
 
   void validate(Map<String, dynamic> config) {
     _validateSectionTypes(config, prefix: '');
@@ -39,7 +61,7 @@ class OlcRtcConfigValidator {
 
     final profiles = profilesValue is List ? profilesValue : const [];
     if (profiles.isEmpty) {
-      _validateEffectiveConfig(config, label: 'olcrtc node');
+      _validateEffectiveConfig(config, path: 'olcrtc');
       return;
     }
 
@@ -56,51 +78,53 @@ class OlcRtcConfigValidator {
       _validateSectionTypes(normalized, prefix: 'profiles[$index].');
       _validateEffectiveConfig(
         _overlayProfile(config, normalized),
-        label: 'olcrtc profile `${_string(normalized['name']) ?? index + 1}`',
+        path: 'olcrtc.profiles[$index]',
       );
     }
   }
 
   void _validateEffectiveConfig(
     Map<String, dynamic> config, {
-    required String label,
+    required String path,
   }) {
     final auth = _section(config, 'auth');
     final provider = _exactString(auth['provider']);
     if (provider == null) {
-      throw FormatException('$label requires non-empty `auth.provider`.');
+      throw FormatException('$path.auth.provider must be non-empty.');
     }
     if (!supportedProviders.contains(provider)) {
       throw FormatException(
-        '$label has unsupported `auth.provider: $provider`; supported values: '
+        '$path.auth.provider has unsupported value `$provider`; supported values: '
         '${supportedProviders.join(', ')}.',
       );
     }
 
     if (provider != 'none' &&
         _exactString(_section(config, 'room')['id']) == null) {
-      throw FormatException('$label requires non-empty `room.id`.');
+      throw FormatException(
+        '$path.room.id must be non-empty when $path.auth.provider is not `none`.',
+      );
     }
 
     final crypto = _section(config, 'crypto');
     final key = _exactString(crypto['key']);
     if (key == null) {
-      throw FormatException('$label requires non-empty `crypto.key`.');
+      throw FormatException('$path.crypto.key must be non-empty.');
     }
     if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(key)) {
       throw FormatException(
-        '$label requires `crypto.key` to contain exactly 64 hexadecimal characters.',
+        '$path.crypto.key must contain exactly 64 hexadecimal characters.',
       );
     }
 
     final net = _section(config, 'net');
     final transport = _exactString(net['transport']);
     if (transport == null) {
-      throw FormatException('$label requires non-empty `net.transport`.');
+      throw FormatException('$path.net.transport must be non-empty.');
     }
     if (!supportedTransports.contains(transport)) {
       throw FormatException(
-        '$label has unsupported `net.transport: $transport`; supported values: '
+        '$path.net.transport has unsupported value `$transport`; supported values: '
         '${supportedTransports.join(', ')}.',
       );
     }
@@ -108,12 +132,12 @@ class OlcRtcConfigValidator {
     final dns = _exactString(net['dns']);
     if (dns == null) {
       throw FormatException(
-        '$label requires `net.dns` in `host:port` format, for example `1.1.1.1:53`.',
+        '$path.net.dns must use `host:port`, for example `1.1.1.1:53`.',
       );
     }
     if (!_isHostPort(dns)) {
       throw FormatException(
-        '$label has invalid `net.dns: $dns`; expected `host:port`.',
+        '$path.net.dns has invalid value `$dns`; expected `host:port`.',
       );
     }
 
@@ -122,7 +146,7 @@ class OlcRtcConfigValidator {
         config,
         section: 'vp8',
         fields: const ['fps', 'batch_size'],
-        label: label,
+        path: path,
       );
     } else if (transport == 'seichannel') {
       _validatePositiveIntSection(
@@ -134,14 +158,14 @@ class OlcRtcConfigValidator {
           'fragment_size',
           'ack_timeout_ms',
         ],
-        label: label,
+        path: path,
       );
     } else if (transport == 'videochannel') {
       _validatePositiveIntSection(
         config,
         section: 'video',
         fields: const ['width', 'height', 'fps'],
-        label: label,
+        path: path,
       );
     }
 
@@ -152,7 +176,7 @@ class OlcRtcConfigValidator {
         codec != 'qrcode' &&
         codec != 'tile') {
       throw FormatException(
-        '$label has invalid `video.codec: $codec`; supported values: qrcode, tile.',
+        '$path.video.codec has invalid value `$codec`; supported values: qrcode, tile.',
       );
     }
     if (transport == 'videochannel' && codec == 'tile') {
@@ -160,26 +184,32 @@ class OlcRtcConfigValidator {
       final height = _int(video['height']) ?? 1080;
       if (width != 1080 || height != 1080) {
         throw FormatException(
-          '$label requires `video.width: 1080` and `video.height: 1080` for the tile codec.',
+          '$path.video.width and $path.video.height must both be 1080 for the tile codec.',
         );
       }
     }
 
     final liveness = _section(config, 'liveness');
     _validatePositiveDuration(
-        liveness['interval'], '$label `liveness.interval`');
-    _validatePositiveDuration(liveness['timeout'], '$label `liveness.timeout`');
+      liveness['interval'],
+      '$path.liveness.interval',
+    );
+    _validatePositiveDuration(
+      liveness['timeout'],
+      '$path.liveness.timeout',
+    );
     final failures = _int(liveness['failures']);
     if (liveness.containsKey('failures') &&
         (failures == null || failures < 0)) {
       throw FormatException(
-          '$label `liveness.failures` must be a non-negative integer.');
+        '$path.liveness.failures must be a non-negative integer.',
+      );
     }
 
     final lifecycle = _section(config, 'lifecycle');
     _validatePositiveDuration(
       lifecycle['max_session_duration'],
-      '$label `lifecycle.max_session_duration`',
+      '$path.lifecycle.max_session_duration',
     );
 
     final traffic = _section(config, 'traffic');
@@ -189,16 +219,16 @@ class OlcRtcConfigValidator {
             maxPayloadSize < 0 ||
             (maxPayloadSize > 0 && maxPayloadSize < 49))) {
       throw FormatException(
-        '$label `traffic.max_payload_size` must be zero or at least 49.',
+        '$path.traffic.max_payload_size must be zero or at least 49.',
       );
     }
     _validateNonNegativeDuration(
       traffic['min_delay'],
-      '$label `traffic.min_delay`',
+      '$path.traffic.min_delay',
     );
     _validateNonNegativeDuration(
       traffic['max_delay'],
-      '$label `traffic.max_delay`',
+      '$path.traffic.max_delay',
     );
     final minDelay = _goDurationMicroseconds(traffic['min_delay']);
     final maxDelay = _goDurationMicroseconds(traffic['max_delay']);
@@ -207,7 +237,7 @@ class OlcRtcConfigValidator {
         maxDelay > 0 &&
         maxDelay < minDelay) {
       throw FormatException(
-        '$label `traffic.max_delay` must not be less than `traffic.min_delay`.',
+        '$path.traffic.max_delay must not be less than $path.traffic.min_delay.',
       );
     }
   }
@@ -265,7 +295,7 @@ class OlcRtcConfigValidator {
     Map<String, dynamic> config, {
     required String section,
     required List<String> fields,
-    required String label,
+    required String path,
   }) {
     final values = _section(config, section);
     for (final field in fields) {
@@ -275,7 +305,8 @@ class OlcRtcConfigValidator {
       final value = _int(values[field]);
       if (value == null || value <= 0) {
         throw FormatException(
-            '$label `$section.$field` must be a positive integer.');
+          '$path.$section.$field must be a positive integer.',
+        );
       }
     }
   }
@@ -369,14 +400,6 @@ class OlcRtcConfigValidator {
   Map<String, dynamic> _stringKeyedMap(Map value) => value.map(
         (key, mapValue) => MapEntry(key.toString(), mapValue),
       );
-
-  String? _string(Object? value) {
-    if (value is! String) {
-      return null;
-    }
-    final trimmed = value.trim();
-    return trimmed.isEmpty ? null : trimmed;
-  }
 
   String? _exactString(Object? value) {
     if (value is! String || value.isEmpty || value != value.trim()) {

--- a/lib/product/compile/profile_compiler.dart
+++ b/lib/product/compile/profile_compiler.dart
@@ -66,6 +66,7 @@ class ProfileCompiler {
     CompiledProfileMetadata? metadata;
 
     if (rawProfile != null) {
+      builtInProxyCompiler.validateConfig(rawProfile.config);
       if (!context.overrideNetworkSettings) {
         final providerSettings = rawProfile.providerHints.network;
         patchConfig = patchConfig

--- a/lib/product/compile/strict_config_schema_validator.dart
+++ b/lib/product/compile/strict_config_schema_validator.dart
@@ -1,0 +1,224 @@
+import 'dart:math' as math;
+
+import 'built_in_proxy_schema.dart';
+
+class StrictConfigSchemaValidator {
+  const StrictConfigSchemaValidator();
+
+  void validate(
+    Map<String, dynamic> config, {
+    required BuiltInProxySchema schema,
+    String? mode,
+  }) {
+    final rootPath = schema.fields.first.path.split('.').first;
+    final fieldsByPath = <String, BuiltInProxyFieldSchema>{
+      for (final field in schema.fields) field.path: field,
+    };
+    _validateObject(
+      config,
+      schema: schema,
+      fieldsByPath: fieldsByPath,
+      canonicalPath: rootPath,
+      actualPath: rootPath,
+      mode: mode,
+    );
+  }
+
+  void _validateObject(
+    Map<dynamic, dynamic> value, {
+    required BuiltInProxySchema schema,
+    required Map<String, BuiltInProxyFieldSchema> fieldsByPath,
+    required String canonicalPath,
+    required String actualPath,
+    required String? mode,
+  }) {
+    final directFields = _directFields(schema.fields, canonicalPath);
+    final fieldNames = directFields.keys.toList(growable: false);
+
+    for (final entry in value.entries) {
+      if (entry.key is! String) {
+        throw FormatException('$actualPath has a non-string field name.');
+      }
+      final key = entry.key as String;
+      final field = directFields[key];
+      final fieldPath = '$actualPath.$key';
+      if (field == null) {
+        final suggestion = _nearest(key, fieldNames);
+        throw FormatException(
+          '$fieldPath is unknown.${suggestion == null ? '' : ' Did you mean `$suggestion`?'}',
+        );
+      }
+      if (field.forbiddenReason case final reason?) {
+        throw FormatException('$fieldPath is forbidden: $reason.');
+      }
+      if (field.modes.isNotEmpty && !field.modes.contains(mode)) {
+        throw FormatException(
+          '$fieldPath is not available in mode `${mode ?? 'unspecified'}`; '
+          'allowed modes: ${field.modes.join(', ')}.',
+        );
+      }
+
+      _validateValue(entry.value, field: field, actualPath: fieldPath);
+      if (entry.value is Map) {
+        _validateObject(
+          entry.value as Map,
+          schema: schema,
+          fieldsByPath: fieldsByPath,
+          canonicalPath: field.path,
+          actualPath: fieldPath,
+          mode: mode,
+        );
+      } else if (entry.value is List) {
+        _validateList(
+          entry.value as List,
+          schema: schema,
+          fieldsByPath: fieldsByPath,
+          canonicalPath: field.path,
+          actualPath: fieldPath,
+          mode: mode,
+        );
+      }
+    }
+
+    for (final entry in directFields.entries) {
+      final field = entry.value;
+      if (!field.required ||
+          field.forbiddenReason != null ||
+          field.modes.isNotEmpty && !field.modes.contains(mode)) {
+        continue;
+      }
+      if (!value.containsKey(entry.key)) {
+        throw FormatException('$actualPath.${entry.key} is required.');
+      }
+    }
+  }
+
+  void _validateList(
+    List<dynamic> value, {
+    required BuiltInProxySchema schema,
+    required Map<String, BuiltInProxyFieldSchema> fieldsByPath,
+    required String canonicalPath,
+    required String actualPath,
+    required String? mode,
+  }) {
+    final itemSchema = fieldsByPath['$canonicalPath[]'];
+    if (itemSchema == null) {
+      return;
+    }
+    for (var index = 0; index < value.length; index++) {
+      final itemPath = '$actualPath[$index]';
+      _validateValue(value[index], field: itemSchema, actualPath: itemPath);
+      if (itemSchema.type == ConfigValueType.object) {
+        _validateObject(
+          value[index] as Map,
+          schema: schema,
+          fieldsByPath: fieldsByPath,
+          canonicalPath: itemSchema.path,
+          actualPath: itemPath,
+          mode: mode,
+        );
+      }
+    }
+  }
+
+  Map<String, BuiltInProxyFieldSchema> _directFields(
+    List<BuiltInProxyFieldSchema> fields,
+    String parentPath,
+  ) {
+    final prefix = '$parentPath.';
+    final result = <String, BuiltInProxyFieldSchema>{};
+    for (final field in fields) {
+      if (!field.path.startsWith(prefix)) continue;
+      final remainder = field.path.substring(prefix.length);
+      if (remainder.isEmpty || remainder.contains('.')) continue;
+      if (remainder.endsWith('[]')) continue;
+      result[remainder] = field;
+    }
+    return result;
+  }
+
+  void _validateValue(
+    Object? value, {
+    required BuiltInProxyFieldSchema field,
+    required String actualPath,
+  }) {
+    final matchesType = <ConfigValueType>{
+      field.type,
+      ...field.additionalTypes,
+    }.any((type) => _matchesType(value, type));
+    if (!matchesType) {
+      throw FormatException(
+        '$actualPath must be ${_typeLabel(field.type)}; got ${value.runtimeType}.',
+      );
+    }
+    if (field.allowedValues.isNotEmpty &&
+        !field.allowedValues.contains(value)) {
+      throw FormatException(
+        '$actualPath must be one of: ${field.allowedValues.join(', ')}.',
+      );
+    }
+    if (value is num) {
+      if (!value.isFinite) {
+        throw FormatException('$actualPath must be finite.');
+      }
+      final minimum = field.range.minimum;
+      final maximum = field.range.maximum;
+      final belowMinimum = minimum != null &&
+          (value < minimum || field.range.exclusiveMinimum && value == minimum);
+      final aboveMaximum = maximum != null && value > maximum;
+      if (belowMinimum || aboveMaximum) {
+        final lowerBound = minimum == null
+            ? '-infinity'
+            : '${field.range.exclusiveMinimum ? '(' : '['}$minimum';
+        final upperBound = maximum == null ? 'infinity' : '$maximum]';
+        throw FormatException(
+          '$actualPath must be in the range $lowerBound..$upperBound.',
+        );
+      }
+    }
+  }
+
+  bool _matchesType(Object? value, ConfigValueType type) => switch (type) {
+        ConfigValueType.string => value is String,
+        ConfigValueType.boolean => value is bool,
+        ConfigValueType.integer => value is int,
+        ConfigValueType.number => value is num && value.isFinite,
+        ConfigValueType.object => value is Map,
+        ConfigValueType.list => value is List,
+      };
+
+  String _typeLabel(ConfigValueType type) => switch (type) {
+        ConfigValueType.string => 'a string',
+        ConfigValueType.boolean => 'a boolean',
+        ConfigValueType.integer => 'an integer',
+        ConfigValueType.number => 'a finite number',
+        ConfigValueType.object => 'a map',
+        ConfigValueType.list => 'a list',
+      };
+
+  String? _nearest(String value, List<String> candidates) {
+    if (candidates.isEmpty) return null;
+    return candidates.reduce(
+      (best, candidate) => _distance(value, candidate) < _distance(value, best)
+          ? candidate
+          : best,
+    );
+  }
+
+  int _distance(String left, String right) {
+    var previous = List<int>.generate(right.length + 1, (index) => index);
+    for (var i = 0; i < left.length; i++) {
+      final current = <int>[i + 1];
+      for (var j = 0; j < right.length; j++) {
+        current.add(
+          math.min(
+            math.min(current[j] + 1, previous[j + 1] + 1),
+            previous[j] + (left.codeUnitAt(i) == right.codeUnitAt(j) ? 0 : 1),
+          ),
+        );
+      }
+      previous = current;
+    }
+    return previous.last;
+  }
+}

--- a/test/product/compile/built_in_proxy_compiler_udp_test.dart
+++ b/test/product/compile/built_in_proxy_compiler_udp_test.dart
@@ -79,7 +79,7 @@ void main() {
               isA<FormatException>().having(
                 (error) => error.message,
                 'message',
-                contains('requires `udp` to be a boolean'),
+                contains('${type.label}.udp must be a boolean'),
               ),
             ),
           );

--- a/test/product/compile/built_in_proxy_config_validator_test.dart
+++ b/test/product/compile/built_in_proxy_config_validator_test.dart
@@ -1,0 +1,490 @@
+import 'dart:convert';
+
+import 'package:flclashx/models/models.dart';
+import 'package:flclashx/product/compile/built_in_proxy_compiler.dart';
+import 'package:flclashx/product/compile/profile_compiler.dart';
+import 'package:flclashx/product/compile/raw_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const compiler = BuiltInProxyCompiler();
+
+  CompiledBuiltInProxyNodes compile(Map<String, dynamic> node) =>
+      compiler.compile(
+        rawConfig: <String, dynamic>{
+          'proxies': [node],
+        },
+        patchConfig: const ClashConfig(),
+      );
+
+  Matcher failsAt(String path, [String? text]) => throwsA(
+        isA<FormatException>()
+            .having((error) => error.message, 'message', contains(path))
+            .having(
+              (error) => error.message,
+              'detail',
+              text == null ? isNotEmpty : contains(text),
+            ),
+      );
+
+  group('NaiveProxy strict config', () {
+    test('accepts the maximal safe pinned config', () {
+      final result = compile(<String, dynamic>{
+        'name': 'Naive',
+        'type': 'naiveproxy',
+        'udp': false,
+        'proxy': 'https://user:pass@example.com',
+        'insecure-concurrency': 4,
+        'tunnel-timeout': 3600,
+        'idle-timeout': 600,
+        'extra-headers': 'X-Test: value',
+        'host-resolver-rules': 'MAP example.com 203.0.113.10',
+        'resolver-range': '100.64.0.0/10',
+        'connectivity-check': {
+          'urls': ['https://example.org/generate_204'],
+          'required': true,
+          'timeout': 60,
+          'startup-timeout': 300,
+          'retry-interval': 300,
+          'requests': 32,
+          'concurrency': 16,
+          'min-success-ratio': 1.0,
+        },
+      });
+
+      final config = jsonDecode(result.nodes.single.files.values.single) as Map;
+      expect(config['proxy'], 'https://user:pass@example.com');
+      expect(config['insecure-concurrency'], 4);
+    });
+
+    test('accepts the pinned list form for alternative proxy chains', () {
+      final result = compile(<String, dynamic>{
+        'name': 'Naive alternatives',
+        'type': 'naiveproxy',
+        'proxy': [
+          'quic://edge-a.example.com,https://origin.example.com',
+          'https://edge-b.example.com',
+        ],
+      });
+
+      final config = jsonDecode(result.nodes.single.files.values.single) as Map;
+      expect(config['proxy'], hasLength(2));
+    });
+
+    test('accepts canonical decimal strings supported by the pinned parser',
+        () {
+      final result = compile(<String, dynamic>{
+        ..._naive,
+        'insecure-concurrency': '4',
+        'tunnel-timeout': '600',
+        'idle-timeout': '300',
+      });
+
+      final config = jsonDecode(result.nodes.single.files.values.single) as Map;
+      expect(config['insecure-concurrency'], '4');
+      expect(config['tunnel-timeout'], '600');
+      expect(config['idle-timeout'], '300');
+    });
+
+    test('reports semantic proxy-chain failures with the list index', () {
+      expect(
+        () => compile(<String, dynamic>{
+          ..._naive,
+          'proxy': [
+            'https://valid.example.com',
+            'https://tcp.example.com,quic://invalid.example.com',
+          ],
+        }),
+        failsAt('naiveproxy.proxy[1]', 'QUIC'),
+      );
+    });
+
+    test('requires strict CRLF framing for extra headers', () {
+      expect(
+        () => compile(<String, dynamic>{
+          ..._naive,
+          'extra-headers': 'X-First: one\r\nX-Second: two',
+        }),
+        returnsNormally,
+      );
+      for (final value in [
+        'X-First: one\nX-Injected: two',
+        'X-First: one\rX-Injected: two',
+        'Bad Name: value',
+      ]) {
+        expect(
+          () => compile(<String, dynamic>{
+            ..._naive,
+            'extra-headers': value,
+          }),
+          failsAt('naiveproxy.extra-headers'),
+          reason: value,
+        );
+      }
+    });
+
+    test('rejects unknown fields at every depth with nearest-name hints', () {
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'Naive',
+          'type': 'naiveproxy',
+          'proxxy': 'https://example.com',
+        }),
+        failsAt('naiveproxy.proxxy', 'proxy'),
+      );
+      expect(
+        () => compile(<String, dynamic>{
+          ..._naive,
+          'connectivity-check': {'timeot': 5},
+        }),
+        failsAt('naiveproxy.connectivity-check.timeot', 'timeout'),
+      );
+    });
+
+    test('rejects wrong types, ranges, and client-owned fields', () {
+      for (final invalid in <String, Object?>{
+        'proxy': 1,
+        'insecure-concurrency': 0,
+        'tunnel-timeout': double.nan,
+        'idle-timeout': 1.5,
+      }.entries) {
+        expect(
+          () => compile(<String, dynamic>{
+            ..._naive,
+            invalid.key: invalid.value,
+          }),
+          failsAt('naiveproxy.${invalid.key}'),
+          reason: invalid.key,
+        );
+      }
+      for (final field in ['listen', 'server', 'port']) {
+        expect(
+          () => compile(<String, dynamic>{
+            ..._naive,
+            field: field == 'port' ? 1080 : 'value',
+          }),
+          failsAt('naiveproxy.$field', 'owned'),
+          reason: field,
+        );
+      }
+      for (final value in <Object?>[true, false, null, 'yes']) {
+        expect(
+          () => compile(<String, dynamic>{
+            ..._naive,
+            'no-post-quantum': value,
+          }),
+          failsAt('naiveproxy.no-post-quantum', 'cannot be disabled'),
+          reason: '$value',
+        );
+      }
+      expect(
+        () => compile(<String, dynamic>{
+          ..._naive,
+          'connectivity-check': {'min-success-ratio': 0},
+        }),
+        failsAt('naiveproxy.connectivity-check.min-success-ratio'),
+      );
+    });
+  });
+
+  group('ByeDPI strict config', () {
+    test('accepts maximal manual and auto configs', () {
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'ByeDPI manual',
+          'type': 'byedpi',
+          'mode': 'manual',
+          'udp': true,
+          'args': '--fake=-1 -Qr -s3:5+sm -a1',
+        }),
+        returnsNormally,
+      );
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'ByeDPI auto',
+          'type': 'byedpi',
+          'mode': 'auto',
+          'udp': false,
+          'strategies': [
+            '-f-1 -Qr',
+            '--split 3:5+sm --udp-fake=1',
+          ],
+          'strategy-test': {
+            'urls': ['https://example.org/generate_204'],
+            'sni': 'example.org',
+            'timeout': 60,
+            'requests': 32,
+            'concurrency': 16,
+            'min-success-ratio': 1.0,
+          },
+          'selection': {
+            'concurrency': 16,
+            'foreground-timeout': 60,
+            'background': false,
+          },
+          'fallback-args': '-s1+s -a1',
+          'cache': {
+            'ttl': 31536000,
+            'recheck-after': 31536000,
+            'retry-after': 31536000,
+            'failure-threshold': 32,
+          },
+        }),
+        returnsNormally,
+      );
+    });
+
+    test('rejects mode-incompatible and misspelled nested fields', () {
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'ByeDPI',
+          'type': 'byedpi',
+          'mode': 'manual',
+          'args': '-f-1',
+          'strategy-test': <String, dynamic>{},
+        }),
+        failsAt('byedpi.strategy-test', 'mode'),
+      );
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'ByeDPI',
+          'type': 'byedpi',
+          'mode': 'auto',
+          'strategy-test': {'concurency': 2},
+        }),
+        failsAt('byedpi.strategy-test.concurency', 'concurrency'),
+      );
+      expect(
+        () => compile(<String, dynamic>{
+          'name': 'ByeDPI',
+          'type': 'byedpi',
+          'mode': 'auto',
+          'strategy-test': {'min-success-ratio': 0},
+        }),
+        failsAt('byedpi.strategy-test.min-success-ratio'),
+      );
+    });
+  });
+
+  group('OlcRTC strict config', () {
+    test('accepts maximal recursive base and profile configs', () {
+      expect(() => compile(_maximalOlcRtc), returnsNormally);
+    });
+
+    test('rejects unknown fields recursively with indexed paths', () {
+      expect(
+        () => compile(<String, dynamic>{
+          ..._minimalOlcRtc,
+          'profiles': [
+            <String, dynamic>{},
+            {
+              'crypto': {'kee': _key},
+            },
+          ],
+        }),
+        failsAt('olcrtc.profiles[1].crypto.kee', 'key'),
+      );
+    });
+
+    test('reports indexed paths for profile cross-field failures', () {
+      expect(
+        () => compile(<String, dynamic>{
+          ..._minimalOlcRtc,
+          'profiles': [
+            {'name': 'first'},
+            {
+              'name': 'second',
+              'traffic': {'min_delay': '2s', 'max_delay': '1s'},
+            },
+          ],
+        }),
+        failsAt('olcrtc.profiles[1].traffic.max_delay'),
+      );
+    });
+
+    test(
+        'rejects client-owned and unsupported mode fields in base and profiles',
+        () {
+      for (final invalid in <String, Object?>{
+        'mode': 'srv',
+        'data': '/tmp/user-data',
+        'socks': {'host': '0.0.0.0'},
+        'crypto': {'key': _key, 'key_file': 'secret.key'},
+      }.entries) {
+        expect(
+          () => compile(<String, dynamic>{
+            ..._minimalOlcRtc,
+            invalid.key: invalid.value,
+          }),
+          failsAt('olcrtc.${invalid.key}'),
+          reason: invalid.key,
+        );
+      }
+      expect(
+        () => compile(<String, dynamic>{
+          ..._minimalOlcRtc,
+          'profiles': [
+            {
+              'socks': {'port': 9000},
+            },
+          ],
+        }),
+        failsAt('olcrtc.profiles[0].socks.port', 'owned'),
+      );
+    });
+  });
+
+  test('ProfileCompiler validates built-in nodes in the pre-security phase',
+      () {
+    final rawProfile = RawProfile.fromConfig(
+      profile: const Profile(
+        id: 'strict-validation-order',
+        autoUpdateDuration: Duration.zero,
+      ),
+      config: const <String, dynamic>{
+        'proxies': [
+          {
+            ..._naive,
+            'proxxy': 'https://typo.example.com',
+          },
+        ],
+      },
+    );
+
+    expect(
+      () => const ProfileCompiler().compileProfilePatch(
+        rawProfile: rawProfile,
+        context: const ProfilePatchContext(
+          patchConfig: ClashConfig(),
+          overrideNetworkSettings: false,
+        ),
+      ),
+      failsAt('naiveproxy.proxxy', 'proxy'),
+    );
+  });
+}
+
+const _key = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const _naive = <String, dynamic>{
+  'name': 'Naive',
+  'type': 'naiveproxy',
+  'proxy': 'https://user:pass@example.com',
+};
+
+const _minimalOlcRtc = <String, dynamic>{
+  'name': 'OlcRTC',
+  'type': 'olcrtc',
+  'mode': 'cnc',
+  'auth': {'provider': 'jitsi'},
+  'room': {'id': 'https://meet.example.org/room'},
+  'crypto': {'key': _key},
+  'net': {'transport': 'datachannel', 'dns': '1.1.1.1:53'},
+};
+
+final _maximalOlcRtc = <String, dynamic>{
+  'name': 'OlcRTC',
+  'type': 'olcrtc',
+  'mode': 'cnc',
+  'udp': false,
+  'auth': {'provider': 'jitsi', 'token': 'account-token'},
+  'room': {
+    'id': 'https://meet.example.org/room',
+    'channel': 'channel-id',
+  },
+  'crypto': {'key': _key},
+  'net': {'transport': 'videochannel', 'dns': '[2606:4700:4700::1111]:53'},
+  'socks': {
+    'user': 'local-user',
+    'pass': 'local-pass',
+    'proxy_addr': '127.0.0.1',
+    'proxy_port': 65535,
+    'proxy_user': 'upstream-user',
+    'proxy_pass': 'upstream-pass',
+  },
+  'engine': {
+    'name': 'jitsi',
+    'url': 'https://meet.example.org',
+    'token': 'engine-token',
+  },
+  'video': {
+    'width': 1080,
+    'height': 1080,
+    'fps': 30,
+    'bitrate': '2M',
+    'hw': 'none',
+    'qr_size': 256,
+    'qr_recovery': 'low',
+    'codec': 'tile',
+    'tile_module': 4,
+    'tile_rs': 20,
+  },
+  'vp8': {'fps': 30, 'batch_size': 64},
+  'sei': {
+    'fps': 30,
+    'batch_size': 64,
+    'fragment_size': 900,
+    'ack_timeout_ms': 2000,
+  },
+  'liveness': {'interval': '10s', 'timeout': '5s', 'failures': 3},
+  'lifecycle': {'max_session_duration': '6h'},
+  'traffic': {
+    'max_payload_size': 4096,
+    'min_delay': '5ms',
+    'max_delay': '30ms',
+  },
+  'profiles': [
+    {
+      'name': 'fallback',
+      'auth': {'provider': 'wbstream', 'token': 'fallback-token'},
+      'room': {'id': 'fallback-room', 'channel': 'fallback-channel'},
+      'crypto': {'key': _key},
+      'net': {'transport': 'vp8channel', 'dns': '8.8.8.8:53'},
+      'socks': {
+        'user': 'fallback-user',
+        'pass': 'fallback-pass',
+        'proxy_addr': '127.0.0.1',
+        'proxy_port': 1080,
+        'proxy_user': 'proxy-user',
+        'proxy_pass': 'proxy-pass',
+      },
+      'engine': {
+        'name': 'jitsi',
+        'url': 'https://fallback.example.org',
+        'token': 'fallback-engine-token',
+      },
+      'video': {
+        'width': 1920,
+        'height': 1080,
+        'fps': 30,
+        'bitrate': '2M',
+        'hw': 'none',
+        'qr_size': 256,
+        'qr_recovery': 'high',
+        'codec': 'qrcode',
+        'tile_module': 4,
+        'tile_rs': 20,
+      },
+      'vp8': {'fps': 30, 'batch_size': 64},
+      'sei': {
+        'fps': 30,
+        'batch_size': 64,
+        'fragment_size': 900,
+        'ack_timeout_ms': 2000,
+      },
+      'liveness': {'interval': '10s', 'timeout': '5s', 'failures': 3},
+      'lifecycle': {'max_session_duration': '6h'},
+      'traffic': {
+        'max_payload_size': 4096,
+        'min_delay': '5ms',
+        'max_delay': '30ms',
+      },
+    },
+  ],
+  'failover': {'retry_delay': '2s', 'max_cycles': 2},
+  'debug': false,
+  'connectivity-check': {
+    'urls': ['https://example.org/generate_204'],
+    'required': true,
+  },
+};

--- a/test/product/compile/built_in_proxy_schema_test.dart
+++ b/test/product/compile/built_in_proxy_schema_test.dart
@@ -1,0 +1,70 @@
+import 'package:flclashx/product/compile/built_in_proxy_schema.dart';
+import 'package:flclashx/product/runtime/built_in_proxy_types.dart';
+import 'package:flclashx/product/runtime/byedpi_release.dart';
+import 'package:flclashx/product/runtime/naiveproxy_release.dart';
+import 'package:flclashx/product/runtime/olcrtc_release.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('schema registry is pinned to every bundled runtime release', () {
+    expect(
+      builtInProxySchemas[BuiltInProxyType.naiveproxy]!.runtimeVersion,
+      naiveProxyPinnedReleaseTag,
+    );
+    expect(
+      builtInProxySchemas[BuiltInProxyType.byedpi]!.runtimeVersion,
+      byedpiPinnedReleaseTag,
+    );
+    expect(
+      builtInProxySchemas[BuiltInProxyType.olcrtc]!.runtimeVersion,
+      olcRtcPinnedReleaseTag,
+    );
+  });
+
+  test('every schema field carries the complete contract metadata', () {
+    for (final schema in builtInProxySchemas.values) {
+      expect(schema.fields, isNotEmpty, reason: schema.type.label);
+      for (final field in schema.fields) {
+        expect(field.path, startsWith('${schema.type.label}.'));
+        expect(field.type, isNotNull, reason: field.path);
+        expect(field.required, isNotNull, reason: field.path);
+        expect(field.modes, isNotNull, reason: field.path);
+        expect(field.allowedValues, isNotNull, reason: field.path);
+        expect(field.range, isNotNull, reason: field.path);
+        expect(field.defaultValue, isNotNull, reason: field.path);
+      }
+    }
+  });
+
+  test('registry exposes recursive and mode-specific fields', () {
+    final byedpi = builtInProxySchemas[BuiltInProxyType.byedpi]!;
+    expect(
+      byedpi.fields.singleWhere((field) => field.path == 'byedpi.args').modes,
+      {'manual'},
+    );
+    expect(
+      byedpi.fields
+          .singleWhere((field) => field.path == 'byedpi.strategies[]')
+          .modes,
+      {'auto'},
+    );
+
+    final olcrtc = builtInProxySchemas[BuiltInProxyType.olcrtc]!;
+    expect(
+      olcrtc.fields.map((field) => field.path),
+      contains('olcrtc.profiles[].crypto.key'),
+    );
+  });
+
+  test('registry exposes pinned effective OlcRTC defaults', () {
+    final fields = {
+      for (final field in builtInProxySchemas[BuiltInProxyType.olcrtc]!.fields)
+        field.path: field,
+    };
+    expect(fields['olcrtc.failover.retry_delay']!.defaultValue.value, '2s');
+    expect(fields['olcrtc.video.qr_size']!.defaultValue.value, 256);
+    expect(fields['olcrtc.liveness.interval']!.defaultValue.value, '10s');
+    expect(fields['olcrtc.liveness.timeout']!.defaultValue.value, '15s');
+    expect(fields['olcrtc.liveness.failures']!.defaultValue.value, 4);
+  });
+}

--- a/test/product/compile/byedpi_cli_validator_test.dart
+++ b/test/product/compile/byedpi_cli_validator_test.dart
@@ -1,0 +1,254 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flclashx/product/compile/byedpi_cli_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const validator = ByedpiCliValidator();
+
+  test('option table describes short and long forms and all input contexts',
+      () {
+    expect(byedpiCliOptions, isNotEmpty);
+    for (final option in byedpiCliOptions) {
+      expect(option.shortName, hasLength(1));
+      expect(option.longName, isNotEmpty);
+      expect(option.valueKind, isNotNull, reason: option.longName);
+      expect(option.repeatable, isNotNull, reason: option.longName);
+      expect(option.contexts, isNotEmpty, reason: option.longName);
+    }
+  });
+
+  test('accepts long equals, attached short values, and short clusters', () {
+    final result = validator.validate(
+      '--fake=-1 -f-1 -Qr -S -a1',
+      path: 'byedpi.args',
+      context: ByedpiCliContext.args,
+    );
+
+    expect(result.arguments, ['--fake=-1', '-f-1', '-Qr', '-S', '-a1']);
+    expect(
+      result.options.map((option) => (option.name, option.value)).toList(),
+      [
+        ('fake', '-1'),
+        ('fake', '-1'),
+        ('fake-tls-mod', 'r'),
+        ('md5sig', null),
+        ('udp-fake', '1'),
+      ],
+    );
+  });
+
+  test('preserves shell argument order and validates quoted inline data', () {
+    final result = validator.validate(
+      r'''--hosts ':example.com test.example' --ipset=:1.1.1.1/32 --fake-data ':abc\x20def' -s3:5+sm''',
+      path: 'byedpi.strategies[3]',
+      context: ByedpiCliContext.strategy,
+    );
+
+    expect(result.options.map((option) => option.name), [
+      'hosts',
+      'ipset',
+      'fake-data',
+      'split',
+    ]);
+    expect(result.options.first.value, ':example.com test.example');
+  });
+
+  test('accepts every bundled ByeByeDPI strategy line', () {
+    final asset = File(
+      'assets/runtimes/byedpi/android/byebyeedpi-strategies.list',
+    );
+    expect(
+      sha256.convert(asset.readAsBytesSync()).toString(),
+      '0d853dea8a82634d64768eb6252b6e9bdeab5abce1883666ca4f2e223f21d824',
+    );
+    final lines = asset.readAsLinesSync();
+    expect(lines, hasLength(60));
+    final failures = <String>[];
+    for (var index = 0; index < lines.length; index++) {
+      try {
+        validator.validate(
+          lines[index],
+          path: 'byedpi.strategies[$index]',
+          context: ByedpiCliContext.strategy,
+        );
+      } on FormatException catch (error) {
+        failures.add('line ${index + 1}: ${lines[index]}\n$error');
+      }
+    }
+    expect(failures, isEmpty, reason: failures.join('\n\n'));
+  });
+
+  test('rejects client-owned, path-backed, and undocumented internal flags',
+      () {
+    final forbidden = <String>[
+      '--ip=127.0.0.1',
+      '-p1080',
+      '--no-domain',
+      '--no-udp',
+      '--conn-ip=127.0.0.1',
+      '--buf-size=4096',
+      '--max-conn=10',
+      '--debug=1',
+      '--tfo',
+      '--timeout=1',
+      '--def-ttl=8',
+      '--daemon',
+      '--pidfile=/tmp/byedpi.pid',
+      '--transparent',
+      '--protect-path=/tmp/protect',
+      '--cache-file=/tmp/cache',
+      '--copy=1',
+      '--wait-send',
+      '--await-int=1',
+      '--connect-to=socks5://127.0.0.1:1080',
+      '--comment=value',
+      '--cache-merge=1',
+      '--no-ipv6',
+    ];
+    for (final value in forbidden) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.fallback-args',
+          context: ByedpiCliContext.fallbackArgs,
+        ),
+        throwsA(
+          isA<FormatException>()
+              .having(
+                (error) => error.message,
+                'path',
+                contains('byedpi.fallback-args'),
+              )
+              .having(
+                (error) => error.message,
+                'reason',
+                contains('forbidden'),
+              ),
+        ),
+        reason: value,
+      );
+    }
+  });
+
+  test('allows only inline hosts, ipset, and fake-data values', () {
+    for (final value in [
+      '--hosts=:example.com',
+      '--ipset=:1.1.1.1/32',
+      r'--fake-data=:hello\x20world',
+    ]) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.args',
+          context: ByedpiCliContext.args,
+        ),
+        returnsNormally,
+        reason: value,
+      );
+    }
+    for (final value in [
+      '--hosts=hosts.txt',
+      '--ipset=/tmp/ipset',
+      '--fake-data=fake.bin',
+    ]) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.args',
+          context: ByedpiCliContext.args,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains('byedpi.args'), contains('inline')),
+          ),
+        ),
+        reason: value,
+      );
+    }
+  });
+
+  test('validates position, filter, and modifier grammars', () {
+    for (final value in [
+      '-s-1',
+      '-s1:1:0',
+      '-d3:5+sm',
+      '-f1+nme',
+      '--tlsrec=65535',
+      '--tlsrec=0xffff',
+      '--pf=80-443',
+      '--round=1-5',
+      '--proto=t,h,u,i',
+      '--fake-tls-mod=rand,orig,msize=1200',
+      '--mod-http=h,d,r',
+    ]) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.strategies[0]',
+          context: ByedpiCliContext.strategy,
+        ),
+        returnsNormally,
+        reason: value,
+      );
+    }
+    for (final value in [
+      '-s1:0',
+      '-d1+z',
+      '--tlsrec=65536',
+      '--tlsrec=0x10000',
+      '--pf=0',
+      '--round=5-1',
+      '--proto=t,b',
+      '--fake-tls-mod=msize=nope',
+      '--mod-http=h,x',
+    ]) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.strategies[3]',
+          context: ByedpiCliContext.strategy,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('byedpi.strategies[3]'),
+          ),
+        ),
+        reason: value,
+      );
+    }
+  });
+
+  test('rejects missing values, unexpected values, and duplicates', () {
+    for (final value in [
+      '--fake',
+      '--md5sig=value',
+      '--tlsminor 1 --tlsminor 2',
+      "--hosts='unterminated",
+      r'--hosts=:value\',
+    ]) {
+      expect(
+        () => validator.validate(
+          value,
+          path: 'byedpi.args',
+          context: ByedpiCliContext.args,
+        ),
+        throwsA(isA<FormatException>()),
+        reason: value,
+      );
+    }
+    expect(
+      () => validator.validate(
+        '--split=1 --split=2',
+        path: 'byedpi.args',
+        context: ByedpiCliContext.args,
+      ),
+      returnsNormally,
+    );
+  });
+}

--- a/test/product/compile/connectivity_check_compiler_test.dart
+++ b/test/product/compile/connectivity_check_compiler_test.dart
@@ -268,7 +268,7 @@ void main() {
       throwsA(isA<FormatException>().having(
         (error) => error.message,
         'message',
-        contains('Rename it to `strategy-test`'),
+        allOf(contains('byedpi.test'), contains('forbidden')),
       )),
     );
   });

--- a/test/product/compile/olcrtc_config_validator_test.dart
+++ b/test/product/compile/olcrtc_config_validator_test.dart
@@ -42,7 +42,7 @@ void main() {
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          contains('requires `net.dns`'),
+          contains('olcrtc.net.dns'),
         ),
       ),
     );

--- a/test/product/compile/product_profile_validator_test.dart
+++ b/test/product/compile/product_profile_validator_test.dart
@@ -71,7 +71,7 @@ proxies:
           isA<FormatException>().having(
             (error) => error.message,
             'message',
-            contains('requires `net.dns`'),
+            contains('olcrtc.net.dns'),
           ),
         ),
       );
@@ -164,7 +164,7 @@ proxies:
           isA<FormatException>().having(
             (error) => error.message,
             'message',
-            contains('must not override'),
+            allOf(contains('byedpi.port'), contains('forbidden')),
           ),
         ),
       );

--- a/test/product/compile/profile_compiler_test.dart
+++ b/test/product/compile/profile_compiler_test.dart
@@ -1042,7 +1042,6 @@ void main() {
                 {
                   'name': 'fallback',
                   'auth': {'provider': 'telemost'},
-                  'future_safe_option': {'enabled': true},
                 },
               ],
             },
@@ -1100,11 +1099,9 @@ void main() {
       expect(runtimeConfig['socks']['port'], builtInNode.listenPort);
       expect(runtimeConfig['debug'], isTrue);
       expect(runtimeConfig['profiles'][0]['name'], 'fallback');
-      expect(runtimeConfig['profiles'][0]['future_safe_option']['enabled'],
-          isTrue);
     });
 
-    test('rejects unsafe olcrtc local bind overrides', () async {
+    test('rejects unsafe olcrtc local bind overrides before security', () {
       const profile = Profile(
         id: 'profile-olcrtc-bind',
         autoUpdateDuration: Duration.zero,
@@ -1122,98 +1119,60 @@ void main() {
           ],
         },
       );
-      final compiledProfile = compiler.compileProfilePatch(
-        rawProfile: rawProfile,
-        context: const ProfilePatchContext(
-          patchConfig: ClashConfig(),
-          overrideNetworkSettings: false,
-        ),
-      );
-
-      await expectLater(
-        compiler.buildRuntimePlan(
+      expect(
+        () => compiler.compileProfilePatch(
           rawProfile: rawProfile,
-          context: const RuntimePlanBuildContext(
-            isAndroid: false,
+          context: const ProfilePatchContext(
+            patchConfig: ClashConfig(),
             overrideNetworkSettings: false,
-            overrideDns: false,
-            routeMode: RouteMode.config,
-            hasCurrentScript: false,
-            profilesPath: '',
-            readInstalledPackageNames: _readNoInstalledPackages,
           ),
-          securedProfile: SecuredProfilePatch(
-            patchConfig: compiledProfile.patchConfig,
-            metadata: compiledProfile.metadata,
-          ),
-          runtimePatchConfig: compiledProfile.patchConfig,
-          selectedMap: const {},
-          testUrl: 'https://cp.cloudflare.com/generate_204',
-          providerAssetPathResolver: (profileId, type, url) async =>
-              '/tmp/$profileId/$type/$url',
         ),
-        throwsA(isA<FormatException>()),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('olcrtc.socks.host'),
+          ),
+        ),
       );
     });
 
-    test('rejects non-client olcrtc modes and key files', () async {
+    test('rejects non-client olcrtc modes and key files before security', () {
       const profile = Profile(
         id: 'profile-olcrtc-mode',
         autoUpdateDuration: Duration.zero,
       );
 
-      Future<void> expectRejected(Map<String, dynamic> proxy) async {
+      void expectRejected(Map<String, dynamic> proxy) {
         final rawProfile = RawProfile.fromConfig(
           profile: profile,
           config: {
             'proxies': [proxy],
           },
         );
-        final compiledProfile = compiler.compileProfilePatch(
-          rawProfile: rawProfile,
-          context: const ProfilePatchContext(
-            patchConfig: ClashConfig(),
-            overrideNetworkSettings: false,
-          ),
-        );
-
-        await expectLater(
-          compiler.buildRuntimePlan(
+        expect(
+          () => compiler.compileProfilePatch(
             rawProfile: rawProfile,
-            context: const RuntimePlanBuildContext(
-              isAndroid: false,
+            context: const ProfilePatchContext(
+              patchConfig: ClashConfig(),
               overrideNetworkSettings: false,
-              overrideDns: false,
-              routeMode: RouteMode.config,
-              hasCurrentScript: false,
-              profilesPath: '',
-              readInstalledPackageNames: _readNoInstalledPackages,
             ),
-            securedProfile: SecuredProfilePatch(
-              patchConfig: compiledProfile.patchConfig,
-              metadata: compiledProfile.metadata,
-            ),
-            runtimePatchConfig: compiledProfile.patchConfig,
-            selectedMap: const {},
-            testUrl: 'https://cp.cloudflare.com/generate_204',
-            providerAssetPathResolver: (profileId, type, url) async =>
-                '/tmp/$profileId/$type/$url',
           ),
           throwsA(isA<FormatException>()),
         );
       }
 
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Server',
         'type': 'olcrtc',
         'mode': 'srv',
       });
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Key File',
         'type': 'olcrtc',
         'crypto': {'key_file': './olcrtc.key'},
       });
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Nested Bind Host',
         'type': 'olcrtc',
         'profiles': [
@@ -1223,7 +1182,7 @@ void main() {
           },
         ],
       });
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Deep Nested Bind Port',
         'type': 'olcrtc',
         'profiles': [
@@ -1239,7 +1198,7 @@ void main() {
           },
         ],
       });
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Nested Key File',
         'type': 'olcrtc',
         'profiles': [
@@ -1249,7 +1208,7 @@ void main() {
           },
         ],
       });
-      await expectRejected({
+      expectRejected({
         'name': 'OLC Invalid Profiles',
         'type': 'olcrtc',
         'profiles': {'name': 'not-a-list'},


### PR DESCRIPTION
## Summary

- add pinned schema registries and fail-closed recursive validation for NaiveProxy, ByeDPI, and OlcRTC nodes
- validate built-in node configuration before security policy and again before runtime plan generation
- parse ByeDPI argv with short/long option metadata, exact value grammars, forbidden client-owned/process/path flags, and bundled strategy integrity coverage
- reject unsafe NaiveProxy logging/path/PQ controls and OlcRTC non-client modes, key files, and local listener overrides
- report exact nested paths, nearest-key hints, mode violations, and cross-field failures

## Security decisions

- provider input cannot control local listeners, process lifecycle, filesystem paths, debug/log sinks, or TLS key logging
- `no-post-quantum` is rejected because presence disables PQ in the pinned NaiveProxy parser
- ByeDPI process-global controls remain owned by FlClashM; hosts/ipset/fake data accept inline `:value` forms only
- OlcRTC is restricted to client (`cnc`) mode with client-owned data and SOCKS bind settings

## Verification

- `nix develop -c make check`
  - product boundary guard passed
  - release continuity guard passed
  - base drift guard passed
  - 265 product/tool tests passed
  - `flutter analyze --fatal-infos` passed
- all 60 bundled ByeByeDPI strategy entries validate and the asset SHA-256 is pinned
- independent fail-closed source audits used the exact bundled NaiveProxy tag, ByeDPI commit, and OlcRTC commit
