### PR TITLE
Оптимизировать критические пути runtime

### DIFF
--- a/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
@@ -77,6 +77,8 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
 
     private val packages = mutableListOf<Package>()
     private var packagesLoadedAt = 0L
+    private var installedPackageNames: List<String> = emptyList()
+    private var installedPackageNamesLoadedAt = 0L
 
     private val skipPrefixList = listOf(
         "com.google",
@@ -521,15 +523,28 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         }
     }
 
-    private suspend fun getInstalledPackageNames(): String {
+    @Synchronized
+    private fun getInstalledPackageNamesSnapshot(): List<String> {
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (installedPackageNamesLoadedAt != 0L &&
+            now - installedPackageNamesLoadedAt < PACKAGES_CACHE_TTL_MS
+        ) {
+            return installedPackageNames
+        }
+        val packageManager = FlClashApplication.getAppContext().packageManager
+        installedPackageNames = packageManager
+            ?.getInstalledPackages(0)
+            ?.map { it.packageName }
+            ?.filter { it.isNotBlank() }
+            ?.distinct()
+            ?: emptyList()
+        installedPackageNamesLoadedAt = now
+        return installedPackageNames
+    }
+
+    private suspend fun getInstalledPackageNames(): List<String> {
         return withContext(Dispatchers.IO) {
-            val packageManager = FlClashApplication.getAppContext().packageManager
-            val packageNames = packageManager
-                ?.getInstalledPackages(0)
-                ?.map { it.packageName }
-                ?.filter { it.isNotBlank() }
-                ?: emptyList()
-            Gson().toJson(packageNames)
+            getInstalledPackageNamesSnapshot()
         }
     }
 
@@ -725,6 +740,8 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
                 synchronized(this) {
                     packages.clear()
                     packagesLoadedAt = 0L
+                    installedPackageNames = emptyList()
+                    installedPackageNamesLoadedAt = 0L
                 }
             }
             val pending = installedAppsCallbacks.toList()

--- a/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
@@ -4,8 +4,11 @@ import android.Manifest
 import android.app.Activity
 import android.app.ActivityManager
 import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
 import android.content.ClipData
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
 import android.content.pm.ComponentInfo
 import android.content.pm.PackageManager
@@ -79,6 +82,14 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
     private var packagesLoadedAt = 0L
     private var installedPackageNames: List<String> = emptyList()
     private var installedPackageNamesLoadedAt = 0L
+    private var installedAppsPermissionGranted: Boolean? = null
+    private var packageChangesReceiverRegistered = false
+
+    private val packageChangesReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            invalidatePackageCaches()
+        }
+    }
 
     private val skipPrefixList = listOf(
         "com.google",
@@ -151,6 +162,7 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "app")
         channel.setMethodCallHandler(this)
+        registerPackageChangesReceiver()
     }
 
     private fun initShortcuts(toggle: String, start: String, stop: String) {
@@ -176,7 +188,66 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        unregisterPackageChangesReceiver()
         scope.cancel()
+    }
+
+    private fun registerPackageChangesReceiver() {
+        if (packageChangesReceiverRegistered) return
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_PACKAGE_ADDED)
+            addAction(Intent.ACTION_PACKAGE_REMOVED)
+            addAction(Intent.ACTION_PACKAGE_CHANGED)
+            addAction(Intent.ACTION_PACKAGE_REPLACED)
+            addDataScheme("package")
+        }
+        packageChangesReceiverRegistered = runCatching {
+            ContextCompat.registerReceiver(
+                FlClashApplication.getAppContext(),
+                packageChangesReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        }.isSuccess
+    }
+
+    private fun unregisterPackageChangesReceiver() {
+        if (!packageChangesReceiverRegistered) return
+        runCatching {
+            FlClashApplication.getAppContext().unregisterReceiver(packageChangesReceiver)
+        }
+        packageChangesReceiverRegistered = false
+    }
+
+    @Synchronized
+    private fun invalidatePackageCaches() {
+        packages.clear()
+        packagesLoadedAt = 0L
+        installedPackageNames = emptyList()
+        installedPackageNamesLoadedAt = 0L
+        iconMap.clear()
+    }
+
+    private fun hasInstalledAppsPermission(): Boolean {
+        val context = FlClashApplication.getAppContext()
+        val defined = try {
+            context.packageManager?.getPermissionInfo(GET_INSTALLED_APPS_PERMISSION, 0) != null
+        } catch (_: Exception) {
+            false
+        }
+        return !defined || ContextCompat.checkSelfPermission(
+            context,
+            GET_INSTALLED_APPS_PERMISSION,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @Synchronized
+    private fun refreshInstalledAppsPermissionState() {
+        val granted = hasInstalledAppsPermission()
+        if (installedAppsPermissionGranted != null && installedAppsPermissionGranted != granted) {
+            invalidatePackageCaches()
+        }
+        installedAppsPermissionGranted = granted
     }
 
     private fun tip(message: String?) {
@@ -492,6 +563,7 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
 
     @Synchronized
     private fun getPackages(): List<Package> {
+        refreshInstalledAppsPermissionState()
         val packageManager = FlClashApplication.getAppContext().packageManager
         val now = android.os.SystemClock.elapsedRealtime()
         if (packages.isNotEmpty() && now - packagesLoadedAt < PACKAGES_CACHE_TTL_MS) {
@@ -525,6 +597,7 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
 
     @Synchronized
     private fun getInstalledPackageNamesSnapshot(): List<String> {
+        refreshInstalledAppsPermissionState()
         val now = android.os.SystemClock.elapsedRealtime()
         if (installedPackageNamesLoadedAt != 0L &&
             now - installedPackageNamesLoadedAt < PACKAGES_CACHE_TTL_MS
@@ -738,10 +811,8 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
                 // A pre-grant load may have cached the ROM's stripped-down list
                 // moments ago; drop it so the pending callbacks fetch the real one.
                 synchronized(this) {
-                    packages.clear()
-                    packagesLoadedAt = 0L
-                    installedPackageNames = emptyList()
-                    installedPackageNamesLoadedAt = 0L
+                    invalidatePackageCaches()
+                    installedAppsPermissionGranted = true
                 }
             }
             val pending = installedAppsCallbacks.toList()

--- a/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
+++ b/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
@@ -154,8 +154,8 @@ object SavedParams {
 
     fun saveNotificationTitle(title: String) {
         runCatching {
-            if (notifTitleFile.exists() && notifTitleFile.readText() == title) return
-            writeAtomic(notifTitleFile, title)
+            val persistedTitle = runCatching { notifTitleFile.readText() }.getOrNull()
+            if (persistedTitle != title) writeAtomic(notifTitleFile, title)
             legacyNotifTitleFile.delete()
         }
             .onFailure { GlobalState.log("saveNotificationTitle error: ${it.message}") }

--- a/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
+++ b/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
@@ -154,6 +154,7 @@ object SavedParams {
 
     fun saveNotificationTitle(title: String) {
         runCatching {
+            if (notifTitleFile.exists() && notifTitleFile.readText() == title) return
             writeAtomic(notifTitleFile, title)
             legacyNotifTitleFile.delete()
         }

--- a/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
@@ -126,8 +126,9 @@ class RemoteService : Service() {
         }
 
         override fun updateNotificationParams(params: NotificationParams) {
-            if (State.notificationParamsFlow.value == params) return
-            State.notificationParamsFlow.value = params
+            if (State.notificationParamsFlow.value != params) {
+                State.notificationParamsFlow.value = params
+            }
             com.follow.clashx.common.SavedParams.saveNotificationTitle(params.title)
         }
 

--- a/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
@@ -126,6 +126,7 @@ class RemoteService : Service() {
         }
 
         override fun updateNotificationParams(params: NotificationParams) {
+            if (State.notificationParamsFlow.value == params) return
             State.notificationParamsFlow.value = params
             com.follow.clashx.common.SavedParams.saveNotificationTitle(params.title)
         }

--- a/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeConnectivityChecker.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeConnectivityChecker.kt
@@ -81,6 +81,9 @@ data class RuntimeNodeConnectivityCheck(
 }
 
 object RuntimeNodeConnectivityChecker {
+    private val ipv4LiteralPattern = Regex("(?:\\d{1,3}\\.){3}\\d{1,3}")
+    private val httpStatusPattern = Regex("^HTTP/\\d\\.\\d [1-5]\\d{2}(?: .*)?$")
+
     suspend fun checkUntilDeadline(
         nodeId: String,
         host: String,
@@ -151,7 +154,7 @@ object RuntimeNodeConnectivityChecker {
             host.endsWith(".local") || host.endsWith(".internal") ||
             host.endsWith(".home.arpa")
         ) return false
-        val isLiteral = host.contains(':') || host.matches(Regex("(?:\\d{1,3}\\.){3}\\d{1,3}"))
+        val isLiteral = host.contains(':') || host.matches(ipv4LiteralPattern)
         return if (isLiteral) {
             runCatching { InetAddress.getByName(host) }
                 .getOrNull()
@@ -237,7 +240,7 @@ object RuntimeNodeConnectivityChecker {
                     val status = BufferedInputStream(socket.getInputStream())
                         .bufferedReader()
                         .readLine()
-                    status?.matches(Regex("^HTTP/\\d\\.\\d [1-5]\\d{2}(?: .*)?$")) == true
+                    status?.matches(httpStatusPattern) == true
                 } finally {
                     runCatching { socket.close() }
                     if (socket !== rawSocket) runCatching { rawSocket.close() }

--- a/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeProcessManager.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RuntimeNodeProcessManager.kt
@@ -627,7 +627,7 @@ object RuntimeNodeProcessManager {
         readyNodeIds.remove(nodeId)
     }
 
-    private fun killMatchingRuntimeProcesses(spec: RuntimeNodeSpec) {
+    private suspend fun killMatchingRuntimeProcesses(spec: RuntimeNodeSpec) {
         val expected = listOf(spec.executablePath) + spec.arguments
         val selfPid = android.os.Process.myPid()
         val entries = File("/proc").listFiles() ?: return
@@ -655,11 +655,11 @@ object RuntimeNodeProcessManager {
             .filter { it.isNotEmpty() }
     }.getOrNull()
 
-    private fun waitForProcessExit(pid: Int) {
+    private suspend fun waitForProcessExit(pid: Int) {
         val procPath = File("/proc/$pid")
         val deadline = System.currentTimeMillis() + EMERGENCY_WAIT_MILLIS
         while (procPath.exists() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(50L)
+            delay(50L)
         }
     }
 

--- a/android/service/src/main/kotlin/com/follow/clashx/service/modules/NetworkObserveModule.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/modules/NetworkObserveModule.kt
@@ -114,8 +114,9 @@ class NetworkObserveModule(
         }
     }
 
-    private val connectivityManager: ConnectivityManager
-        get() = service.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val connectivityManager: ConnectivityManager by lazy {
+        service.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    }
 
     private fun isSystemNetwork(capabilities: NetworkCapabilities): Boolean {
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&

--- a/lib/application.dart
+++ b/lib/application.dart
@@ -58,6 +58,15 @@ class ApplicationState extends ConsumerState<Application> {
     _autoUpdateProfilesTask();
     globalState.appController = AppController(context, ref);
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+      unawaited(
+        globalState.loadDynamicColor().then((_) {
+          if (!mounted) return;
+          ref.invalidate(genColorSchemeProvider);
+          setState(() {});
+        }).catchError((Object error) {
+          commonPrint.log('Dynamic color init failed: $error');
+        }),
+      );
       final currentContext = globalState.navigatorKey.currentContext;
       if (currentContext != null) {
         globalState.appController = AppController(currentContext, ref);

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -51,7 +51,12 @@ class AppController {
   }
 
   void updateGroupsDebounce() {
-    debouncer.call(FunctionTag.updateGroups, updateGroups);
+    debouncer.call(
+      FunctionTag.updateGroups,
+      () => updateGroups(
+        syncNotification: Platform.isAndroid && globalState.isStart,
+      ),
+    );
   }
 
   void addCheckIpNumDebounce() {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -37,7 +37,6 @@ class AppController {
   Future<bool>? _setupClashConfigFuture;
   ClashConfig? _lastAppliedPatchConfig;
   bool _applyProfileAgain = false;
-  DateTime? _lastRuntimeGroupsSync;
 
   void setupClashConfigDebounce() {
     debouncer.call(FunctionTag.setupClashConfig, () async {
@@ -202,7 +201,6 @@ class AppController {
       await StatusBarManager.updateIcon(isConnected: true);
     }
 
-    _lastRuntimeGroupsSync = null;
     startRunTimeTimer();
     if (!checkProfileModified) {
       return;
@@ -227,7 +225,6 @@ class AppController {
     }
 
     stopRunTimeTimer();
-    _lastRuntimeGroupsSync = null;
     clashCore.resetTraffic();
     _ref.read(trafficsProvider.notifier).clear();
     _ref.read(totalTrafficProvider.notifier).value = Traffic();
@@ -266,20 +263,6 @@ class AppController {
     _ref.read(trafficsProvider.notifier).addTraffic(traffic);
     _ref.read(totalTrafficProvider.notifier).value =
         await clashCore.getTotalTraffic();
-    await _syncRuntimeGroupsForNotification();
-  }
-
-  Future<void> _syncRuntimeGroupsForNotification() async {
-    if (!Platform.isAndroid || !_ref.read(runTimeProvider.notifier).isStart) {
-      return;
-    }
-    final now = DateTime.now();
-    final lastSync = _lastRuntimeGroupsSync;
-    if (lastSync != null && now.difference(lastSync).inSeconds < 6) {
-      return;
-    }
-    _lastRuntimeGroupsSync = now;
-    await updateGroups(syncNotification: true);
   }
 
   void markRuntimeConfigListenerReady() {
@@ -646,6 +629,10 @@ class AppController {
   }) =>
       EngineRuntimePlanRequest(
         patchConfig: patchConfig,
+        settingsRevision: (
+          globalState.runtimePlanSettingsRevision,
+          _ref.read(realTunEnableProvider),
+        ),
         refreshProfile: refreshProfile
             ? () async {
                 await _ref.read(currentProfileProvider)?.checkAndUpdate();
@@ -1171,15 +1158,18 @@ class AppController {
     await handleExit();
   }
 
-  Future<bool> _initCore() => globalState.engineManager.initializeCore(
-        runtimePlanRequest: _buildRuntimePlanRequest(
-          patchConfig: _ref.read(patchClashConfigProvider),
-        ),
-        coldStartPatchConfig: _buildColdStartPatchConfig(
-          _ref.read(patchClashConfigProvider),
-        ),
-        setupRuntimePlan: false,
-      );
+  Future<bool> _initCore() async {
+    await globalState.corePreload;
+    return globalState.engineManager.initializeCore(
+      runtimePlanRequest: _buildRuntimePlanRequest(
+        patchConfig: _ref.read(patchClashConfigProvider),
+      ),
+      coldStartPatchConfig: _buildColdStartPatchConfig(
+        _ref.read(patchClashConfigProvider),
+      ),
+      setupRuntimePlan: false,
+    );
+  }
 
   Future<void> init() async {
     FlutterError.onError = (details) {
@@ -1207,10 +1197,14 @@ class AppController {
       clashCore.stopLog();
     }
     await _initStatus();
+    Future<bool>? preload;
     if (!_ref.read(runTimeProvider.notifier).isStart) {
-      await _preloadClashConfig();
+      preload = _preloadClashConfig();
     }
     _ref.read(initProvider.notifier).value = true;
+    if (preload != null) {
+      unawaited(preload);
+    }
     autoLaunch?.updateStatus(_ref.read(appSettingProvider).autoLaunch);
     unawaited(_runStartupMaintenance());
     if (!Platform.isMacOS) {

--- a/lib/plugins/app.dart
+++ b/lib/plugins/app.dart
@@ -52,13 +52,10 @@ class App {
   }
 
   Future<List<String>> getInstalledPackageNames() async {
-    final packageNamesString =
-        await methodChannel.invokeMethod<String>("getInstalledPackageNames");
-    return Isolate.run<List<String>>(() {
-      final List<dynamic> packageNamesRaw =
-          packageNamesString != null ? json.decode(packageNamesString) : [];
-      return packageNamesRaw.map((e) => e.toString()).toList();
-    });
+    final packageNames = await methodChannel.invokeMethod<List<dynamic>>(
+      "getInstalledPackageNames",
+    );
+    return packageNames?.map((value) => value.toString()).toList() ?? const [];
   }
 
   Future<List<String>> getChinaPackageNames() async {

--- a/lib/product/bootstrap/app_bootstrap.dart
+++ b/lib/product/bootstrap/app_bootstrap.dart
@@ -9,6 +9,7 @@ import '../../clash/core.dart';
 import '../../clash/lib.dart';
 import '../../common/android.dart';
 import '../../common/http.dart';
+import '../../common/print.dart';
 import '../../common/system.dart';
 import '../../state.dart';
 import '../android/android_entrypoint.dart';
@@ -18,6 +19,7 @@ class AppBootstrap {
   const AppBootstrap._();
 
   static Future<void> run() async {
+    final bootstrapTimer = Stopwatch()..start();
     WidgetsFlutterBinding.ensureInitialized();
 
     if (!productPlatform.supported) {
@@ -26,8 +28,8 @@ class AppBootstrap {
       );
     }
 
+    globalState.corePreload = clashCore.preload();
     final version = await system.version;
-    await clashCore.preload();
     await globalState.initApp(version);
     await android?.init();
     await androidEntrypoint.init();
@@ -37,5 +39,22 @@ class AppBootstrap {
 
     HttpOverrides.global = FlClashHttpOverrides();
     runApp(const ProviderScope(child: Application()));
+    commonPrint.log(
+      '[Perf] bootstrap.runAppMs=${bootstrapTimer.elapsedMilliseconds}',
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      commonPrint.log(
+        '[Perf] bootstrap.firstFrameMs=${bootstrapTimer.elapsedMilliseconds}',
+      );
+    });
+    unawaited(
+      globalState.corePreload.then((_) {
+        commonPrint.log(
+          '[Perf] bootstrap.corePreloadMs=${bootstrapTimer.elapsedMilliseconds}',
+        );
+      }).catchError((Object error) {
+        commonPrint.log('[Perf] bootstrap.corePreloadFailed=$error');
+      }),
+    );
   }
 }

--- a/lib/product/bootstrap/app_bootstrap.dart
+++ b/lib/product/bootstrap/app_bootstrap.dart
@@ -44,7 +44,8 @@ class AppBootstrap {
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       commonPrint.log(
-        '[Perf] bootstrap.firstFrameMs=${bootstrapTimer.elapsedMilliseconds}',
+        '[Perf] bootstrap.firstFrameCallbackMs='
+        '${bootstrapTimer.elapsedMilliseconds}',
       );
     });
     unawaited(

--- a/lib/product/compile/built_in_proxy_compiler.dart
+++ b/lib/product/compile/built_in_proxy_compiler.dart
@@ -69,11 +69,13 @@ class BuiltInProxyCompiler {
     required Map<String, dynamic> rawConfig,
     required ClashConfig patchConfig,
     String globalTestUrl = '',
+    bool copyConfig = true,
+    bool validate = true,
   }) {
-    final normalizedConfig = copyConfigTree(rawConfig);
+    final normalizedConfig = copyConfig ? copyConfigTree(rawConfig) : rawConfig;
     final proxyEntries = normalizedConfig['proxies'];
     if (proxyEntries is! List) {
-      validateConfig(normalizedConfig);
+      if (validate) validateConfig(normalizedConfig);
       normalizedConfig.remove('x-flclashm-runtime');
       return CompiledBuiltInProxyNodes(
         config: normalizedConfig,
@@ -81,7 +83,7 @@ class BuiltInProxyCompiler {
       );
     }
 
-    validateConfig(normalizedConfig);
+    if (validate) validateConfig(normalizedConfig);
     normalizedConfig.remove('x-flclashm-runtime');
 
     final reservedPorts = _collectReservedPorts(

--- a/lib/product/compile/config_tree.dart
+++ b/lib/product/compile/config_tree.dart
@@ -3,13 +3,30 @@ Map<String, dynamic> copyConfigTree(Map<String, dynamic> source) => {
         entry.key: _copyConfigValue(entry.value),
     };
 
+Map<String, dynamic> freezeConfigTree(Map<String, dynamic> source) =>
+    Map<String, dynamic>.unmodifiable({
+      for (final entry in source.entries)
+        entry.key: _freezeConfigValue(entry.value),
+    });
+
+dynamic _freezeConfigValue(dynamic value) => switch (value) {
+      final Map<dynamic, dynamic> map => Map<String, dynamic>.unmodifiable({
+          for (final entry in map.entries)
+            entry.key.toString(): _freezeConfigValue(entry.value),
+        }),
+      final List<dynamic> list => List<dynamic>.unmodifiable(
+          list.map(_freezeConfigValue),
+        ),
+      _ => value,
+    };
+
 dynamic _copyConfigValue(dynamic value) => switch (value) {
       final Map<dynamic, dynamic> map => <String, dynamic>{
           for (final entry in map.entries)
             entry.key.toString(): _copyConfigValue(entry.value),
         },
       final List<dynamic> list => [
-          for (final item in list) _copyConfigValue(item),
+          for (final item in list) _copyConfigValue(item)
         ],
       _ => value,
     };

--- a/lib/product/compile/loaded_profile_repository.dart
+++ b/lib/product/compile/loaded_profile_repository.dart
@@ -24,7 +24,9 @@ class LoadedProfileRepository {
     _loading = task;
     try {
       final loaded = await task;
-      if (_loadingRevision == revision) _cached = loaded;
+      if (identical(_loading, task) && _loadingRevision == revision) {
+        _cached = loaded;
+      }
       return loaded;
     } finally {
       if (identical(_loading, task)) {
@@ -36,5 +38,7 @@ class LoadedProfileRepository {
 
   void clear() {
     _cached = null;
+    _loading = null;
+    _loadingRevision = null;
   }
 }

--- a/lib/product/compile/loaded_profile_repository.dart
+++ b/lib/product/compile/loaded_profile_repository.dart
@@ -1,0 +1,40 @@
+import 'raw_profile.dart';
+
+typedef LoadRawProfileRevision = Future<RawProfile> Function();
+
+/// Process-local cache for the immutable, evaluated profile revision.
+///
+/// Callers still stat the profile before every request. YAML parsing and script
+/// evaluation are shared only when the complete revision key matches.
+class LoadedProfileRepository {
+  RawProfile? _cached;
+  RawProfileRevision? _loadingRevision;
+  Future<RawProfile>? _loading;
+
+  Future<RawProfile> load(
+    RawProfileRevision revision,
+    LoadRawProfileRevision loader,
+  ) async {
+    final cached = _cached;
+    if (cached?.revision == revision) return cached!;
+    if (_loadingRevision == revision && _loading != null) return _loading!;
+
+    final task = loader();
+    _loadingRevision = revision;
+    _loading = task;
+    try {
+      final loaded = await task;
+      if (_loadingRevision == revision) _cached = loaded;
+      return loaded;
+    } finally {
+      if (identical(_loading, task)) {
+        _loading = null;
+        _loadingRevision = null;
+      }
+    }
+  }
+
+  void clear() {
+    _cached = null;
+  }
+}

--- a/lib/product/compile/product_compile.dart
+++ b/lib/product/compile/product_compile.dart
@@ -1,4 +1,5 @@
 export 'built_in_proxy_compiler.dart';
+export 'loaded_profile_repository.dart';
 export 'olcrtc_config_validator.dart';
 export 'product_profile_pipeline.dart';
 export 'product_profile_validator.dart';

--- a/lib/product/compile/profile_compiler.dart
+++ b/lib/product/compile/profile_compiler.dart
@@ -134,6 +134,8 @@ class ProfileCompiler {
       rawConfig: resolvedProfileSplitTunneling.config,
       patchConfig: patchConfig,
       globalTestUrl: testUrl,
+      copyConfig: false,
+      validate: false,
     );
     rawConfig = compiledBuiltInProxyNodes.config;
 

--- a/lib/product/compile/profile_split_tunneling.dart
+++ b/lib/product/compile/profile_split_tunneling.dart
@@ -15,6 +15,8 @@ typedef ReadProfileSplitTunnelingRemoteSource = Future<String> Function(
   String url,
 );
 
+const _remotePackageListRefreshInterval = Duration(hours: 6);
+
 @immutable
 class ResolvedProfileSplitTunneling {
   const ResolvedProfileSplitTunneling({
@@ -479,12 +481,15 @@ Future<_PackageListReadResult> _readPackageListFromRemoteSource(
   final cacheFile = File(cachePath);
   await cacheFile.parent.create(recursive: true);
   if (cacheFile.existsSync()) {
-    _scheduleRemotePackageListRefresh(
-      url: rawUrl,
-      cachePath: cachePath,
-      fieldName: fieldName,
-      readRemoteSource: readRemoteSource,
-    );
+    final cacheAge = DateTime.now().difference(cacheFile.lastModifiedSync());
+    if (cacheAge >= _remotePackageListRefreshInterval || cacheAge.isNegative) {
+      _scheduleRemotePackageListRefresh(
+        url: rawUrl,
+        cachePath: cachePath,
+        fieldName: fieldName,
+        readRemoteSource: readRemoteSource,
+      );
+    }
     return _PackageListReadResult(
       content: await cacheFile.readAsString(),
       cachePath: cachePath,
@@ -760,6 +765,7 @@ List<String> _resolvePackageSelectors(
         .map((item) => item.trim())
         .where((item) => item.isNotEmpty),
   ).toList();
+  final installedPackageSet = normalizedInstalledPackages.toSet();
 
   if (normalizedInstalledPackages.isEmpty) {
     final resolvedPackages = <String>{};
@@ -794,8 +800,11 @@ List<String> _resolvePackageSelectors(
   final resolvedPackages = <String>{};
   for (var index = 0; index < compiledSelectors.length; index++) {
     final selector = compiledSelectors[index];
-    final matches =
-        normalizedInstalledPackages.where(selector.matches).toList();
+    final matches = selector.requiresInstalledPackageScan
+        ? normalizedInstalledPackages.where(selector.matches).toList()
+        : installedPackageSet.contains(selector.pattern)
+            ? <String>[selector.pattern]
+            : const <String>[];
     matchCounters[index] = matches.length;
     if (matches.isEmpty) {
       continue;

--- a/lib/product/compile/raw_profile.dart
+++ b/lib/product/compile/raw_profile.dart
@@ -2,6 +2,46 @@ import 'package:flclashx/enum/enum.dart';
 import 'package:flclashx/models/models.dart';
 import 'package:flutter/foundation.dart';
 
+import 'config_tree.dart';
+
+@immutable
+class RawProfileRevision {
+  const RawProfileRevision({
+    required this.profile,
+    required this.lastModifiedMicros,
+    required this.fileSize,
+    this.scriptId,
+    this.scriptContent,
+  });
+
+  final Profile profile;
+  final int lastModifiedMicros;
+  final int fileSize;
+  final String? scriptId;
+  final String? scriptContent;
+
+  @override
+  bool operator ==(Object other) =>
+      other is RawProfileRevision &&
+      other.profile.id == profile.id &&
+      other.profile.overrideData == profile.overrideData &&
+      other.lastModifiedMicros == lastModifiedMicros &&
+      other.fileSize == fileSize &&
+      other.scriptId == scriptId &&
+      other.scriptContent == scriptContent;
+
+  @override
+  int get hashCode =>
+      Object.hash(
+        profile.id,
+        profile.overrideData,
+        lastModifiedMicros,
+        fileSize,
+        scriptId,
+        scriptContent,
+      );
+}
+
 @immutable
 class RawProfile {
   const RawProfile({
@@ -9,15 +49,17 @@ class RawProfile {
     required this.config,
     required this.groupDescriptions,
     required this.providerHints,
+    this.revision,
   });
 
   factory RawProfile.fromConfig({
     required Profile profile,
     required Map<String, dynamic> config,
+    RawProfileRevision? revision,
   }) =>
       RawProfile(
         profile: profile,
-        config: config,
+        config: freezeConfigTree(config),
         groupDescriptions: _parseGroupDescriptions(config["proxy-groups"]),
         providerHints: ProviderAdvisoryHints(
           network: ProviderNetworkHints(
@@ -36,12 +78,14 @@ class RawProfile {
           externalController:
               _trimmedString(config["external-controller"]) ?? "",
         ),
+        revision: revision,
       );
 
   final Profile profile;
   final Map<String, dynamic> config;
   final Map<String, String> groupDescriptions;
   final ProviderAdvisoryHints providerHints;
+  final RawProfileRevision? revision;
 
   static Map<String, String> _parseGroupDescriptions(Object? groups) {
     final descriptions = <String, String>{};

--- a/lib/product/runtime/built_in_proxy_supervisor.dart
+++ b/lib/product/runtime/built_in_proxy_supervisor.dart
@@ -56,6 +56,7 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     this.healthProbe,
     Duration Function()? monotonicNow,
     Future<void> Function(Duration)? delay,
+    this.healthProbeTimeout = const Duration(seconds: 5),
   })  : naiveProxy = naiveProxy ?? NaiveProxyNodeController(),
         byedpi = byedpi ?? ByedpiNodeController(),
         olcRtc = olcRtc ?? OlcRtcNodeController(),
@@ -74,6 +75,7 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
   final RuntimeHealthProbe? healthProbe;
   final Duration Function() monotonicNow;
   final Future<void> Function(Duration) delay;
+  final Duration healthProbeTimeout;
 
   List<BuiltInProxyNodePlan> _currentPlans = const [];
   Set<String> _awakeReserveNodeIds = <String>{};
@@ -110,19 +112,27 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
       await _cancelWatchdog();
       await byedpi.cancelBackgroundSelection();
       _rollbackAwakeReserveNodeIds = Set<String>.from(_awakeReserveNodeIds);
-      final naiveMessage = await naiveProxy.stageRuntimePlan(
-        currentPlans: _filter(_currentPlans, BuiltInProxyType.naiveproxy),
-        nextPlans: _filter(plans, BuiltInProxyType.naiveproxy),
-      );
+      final currentNaive = _filter(_currentPlans, BuiltInProxyType.naiveproxy);
+      final nextNaive = _filter(plans, BuiltInProxyType.naiveproxy);
+      final naiveMessage = currentNaive.isEmpty && nextNaive.isEmpty
+          ? ''
+          : await naiveProxy.stageRuntimePlan(
+              currentPlans: currentNaive,
+              nextPlans: nextNaive,
+            );
       if (naiveMessage.isNotEmpty) {
         _startWatchdog(_planGeneration);
         return naiveMessage;
       }
 
-      final byedpiMessage = await byedpi.stageRuntimePlan(
-        currentPlans: _filter(_currentPlans, BuiltInProxyType.byedpi),
-        nextPlans: _filter(plans, BuiltInProxyType.byedpi),
-      );
+      final currentByedpi = _filter(_currentPlans, BuiltInProxyType.byedpi);
+      final nextByedpi = _filter(plans, BuiltInProxyType.byedpi);
+      final byedpiMessage = currentByedpi.isEmpty && nextByedpi.isEmpty
+          ? ''
+          : await byedpi.stageRuntimePlan(
+              currentPlans: currentByedpi,
+              nextPlans: nextByedpi,
+            );
       if (byedpiMessage.isNotEmpty) {
         final rollback = await naiveProxy.rollbackStagedRuntimePlan();
         _startWatchdog(_planGeneration);
@@ -131,10 +141,14 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
             : '$byedpiMessage Local-node rollback failed: $rollback';
       }
 
-      final olcMessage = await olcRtc.stageRuntimePlan(
-        currentPlans: _filter(_currentPlans, BuiltInProxyType.olcrtc),
-        nextPlans: _filter(plans, BuiltInProxyType.olcrtc),
-      );
+      final currentOlcRtc = _filter(_currentPlans, BuiltInProxyType.olcrtc);
+      final nextOlcRtc = _filter(plans, BuiltInProxyType.olcrtc);
+      final olcMessage = currentOlcRtc.isEmpty && nextOlcRtc.isEmpty
+          ? ''
+          : await olcRtc.stageRuntimePlan(
+              currentPlans: currentOlcRtc,
+              nextPlans: nextOlcRtc,
+            );
       if (olcMessage.isEmpty) {
         _awakeReserveNodeIds.clear();
         _reserveStates.clear();
@@ -360,7 +374,12 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     }
     _watchdogCancellation = null;
     final worker = _watchdogWorker;
-    await worker;
+    try {
+      await worker?.timeout(healthProbeTimeout);
+    } on TimeoutException {
+      // RuntimeHealthProbe has no cancellation primitive. The generation checks
+      // after every probe boundary prevent a late result touching a newer plan.
+    }
     if (identical(_watchdogWorker, worker)) _watchdogWorker = null;
   }
 
@@ -404,7 +423,10 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     final probe = healthProbe!;
     bool hasNetwork;
     try {
-      hasNetwork = await probe.hasDeviceNetwork();
+      hasNetwork = await probe.hasDeviceNetwork().timeout(
+            healthProbeTimeout,
+            onTimeout: () => false,
+          );
     } catch (_) {
       hasNetwork = false;
     }
@@ -415,10 +437,12 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     }
     bool healthy;
     try {
-      healthy = await probe.testDelay(
-        proxyName: plan.activation!.watchGroup,
-        urls: plan.activation!.wakeUrls,
-      );
+      healthy = await probe
+          .testDelay(
+            proxyName: plan.activation!.watchGroup,
+            urls: plan.activation!.wakeUrls,
+          )
+          .timeout(healthProbeTimeout, onTimeout: () => false);
     } catch (_) {
       healthy = false;
     }
@@ -475,10 +499,12 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
           }
           final probe = healthProbe;
           if (probe != null) {
-            final alive = await probe.testDelay(
-              proxyName: plan.name,
-              urls: plan.activation!.wakeUrls,
-            );
+            final alive = await probe
+                .testDelay(
+                  proxyName: plan.name,
+                  urls: plan.activation!.wakeUrls,
+                )
+                .timeout(healthProbeTimeout, onTimeout: () => false);
             if (generation != _planGeneration) {
               await _restoreSleepingReserve(plan.nodeId);
               return;
@@ -547,7 +573,10 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     final probe = healthProbe!;
     List<List<String>> chains;
     try {
-      chains = await probe.activeConnectionChains();
+      chains = await probe.activeConnectionChains().timeout(
+            healthProbeTimeout,
+            onTimeout: () => const <List<String>>[],
+          );
     } catch (_) {
       state.idleSince = null;
       return;
@@ -555,7 +584,9 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     if (generation != _planGeneration) return;
     Map<String, String> selections;
     try {
-      selections = await probe.selectedProxies(activation.containingGroups);
+      selections = await probe
+          .selectedProxies(activation.containingGroups)
+          .timeout(healthProbeTimeout, onTimeout: () => const {});
     } catch (_) {
       state.idleSince = null;
       return;

--- a/lib/product/runtime/built_in_proxy_supervisor.dart
+++ b/lib/product/runtime/built_in_proxy_supervisor.dart
@@ -573,10 +573,7 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     final probe = healthProbe!;
     List<List<String>> chains;
     try {
-      chains = await probe.activeConnectionChains().timeout(
-            healthProbeTimeout,
-            onTimeout: () => const <List<String>>[],
-          );
+      chains = await probe.activeConnectionChains().timeout(healthProbeTimeout);
     } catch (_) {
       state.idleSince = null;
       return;
@@ -586,7 +583,7 @@ class DefaultBuiltInProxySupervisor implements BuiltInProxySupervisor {
     try {
       selections = await probe
           .selectedProxies(activation.containingGroups)
-          .timeout(healthProbeTimeout, onTimeout: () => const {});
+          .timeout(healthProbeTimeout);
     } catch (_) {
       state.idleSince = null;
       return;

--- a/lib/product/runtime/engine_manager.dart
+++ b/lib/product/runtime/engine_manager.dart
@@ -20,22 +20,19 @@ typedef CompileProfilePatchCallback = CompiledProfilePatch Function({
 typedef EnforceSecurityPolicyCallback = SecuredProfilePatch Function({
   required CompiledProfilePatch compiledProfile,
 });
-typedef SecureRuntimeUpdateCallback = UpdateParams Function({
-  required UpdateParams updateParams,
-});
+typedef SecureRuntimeUpdateCallback = UpdateParams Function(
+    {required UpdateParams updateParams});
 typedef BuildRuntimePlanCallback = Future<RuntimePlan> Function({
   required RawProfile? rawProfile,
   required SecuredProfilePatch securedProfile,
   required ClashConfig runtimePatchConfig,
 });
 typedef ApplyRuntimePlanCallback = void Function(RuntimePlan runtimePlan);
-typedef BuildCoreStateCallback = CoreState Function({
-  AccessControl? profileAccessControl,
-});
+typedef BuildCoreStateCallback = CoreState Function(
+    {AccessControl? profileAccessControl});
 typedef BuildInitParamsCallback = Future<InitParams> Function();
-typedef ResolveTunAccessCallback = FutureOr<ResolvedTunAccess> Function({
-  required bool requestedTunEnable,
-});
+typedef ResolveTunAccessCallback = FutureOr<ResolvedTunAccess> Function(
+    {required bool requestedTunEnable});
 
 @immutable
 class ResolvedTunAccess {
@@ -58,12 +55,14 @@ class ResolvedTunAccess {
 class EngineRuntimePlanRequest {
   const EngineRuntimePlanRequest({
     required this.patchConfig,
+    this.settingsRevision,
     this.refreshProfile,
     this.resolveTunAccess,
     this.onPatchConfigResolved,
   });
 
   final ClashConfig patchConfig;
+  final Object? settingsRevision;
   final FutureOr<void> Function()? refreshProfile;
   final ResolveTunAccessCallback? resolveTunAccess;
   final ValueChanged<ClashConfig>? onPatchConfigResolved;
@@ -87,12 +86,40 @@ class _CompiledRuntimePlan {
     required this.resolvedRuntime,
     required this.rawProfile,
     required this.securedProfile,
+    required this.requestedPatchConfig,
+    required this.settingsRevision,
   });
 
   final AppliedRuntimePlan appliedRuntimePlan;
   final ResolvedRuntimeSelection resolvedRuntime;
   final RawProfile? rawProfile;
   final SecuredProfilePatch securedProfile;
+  final ClashConfig requestedPatchConfig;
+  final Object? settingsRevision;
+}
+
+class EnginePerformanceCounters {
+  int rawProfileLoads = 0;
+  int profileCompilations = 0;
+  int runtimePlanBuilds = 0;
+  int verifiedPlanReuses = 0;
+  int coldStartPlanDerivations = 0;
+  int coldStartSnapshotsSkipped = 0;
+  int coldStartRequestsCoalesced = 0;
+}
+
+class _ColdStartPersistenceRequest {
+  const _ColdStartPersistenceRequest({
+    required this.compiledRuntimePlan,
+    required this.patchConfig,
+  });
+
+  final _CompiledRuntimePlan? compiledRuntimePlan;
+  final ClashConfig patchConfig;
+
+  bool sameSnapshotAs(_ColdStartPersistenceRequest other) =>
+      identical(compiledRuntimePlan, other.compiledRuntimePlan) &&
+      patchConfig == other.patchConfig;
 }
 
 class EngineManager {
@@ -106,6 +133,7 @@ class EngineManager {
     required ApplyRuntimePlanCallback applyRuntimePlan,
     required BuildCoreStateCallback buildCoreState,
     required BuildInitParamsCallback buildInitParams,
+    EnginePerformanceCounters? performanceCounters,
   })  : _runtimeRegistry = runtimeRegistry,
         _activeRuntime = runtimeRegistry.resolveSelection(),
         _loadCurrentRawProfile = loadCurrentRawProfile,
@@ -115,7 +143,9 @@ class EngineManager {
         _buildRuntimePlan = buildRuntimePlan,
         _applyRuntimePlan = applyRuntimePlan,
         _buildCoreState = buildCoreState,
-        _buildInitParams = buildInitParams;
+        _buildInitParams = buildInitParams,
+        performanceCounters =
+            performanceCounters ?? EnginePerformanceCounters();
 
   final RuntimeRegistry _runtimeRegistry;
   ResolvedRuntimeSelection _activeRuntime;
@@ -127,13 +157,18 @@ class EngineManager {
   final ApplyRuntimePlanCallback _applyRuntimePlan;
   final BuildCoreStateCallback _buildCoreState;
   final BuildInitParamsCallback _buildInitParams;
+  final EnginePerformanceCounters performanceCounters;
 
   Timer? _updateTimer;
   int _tasksEpoch = 0;
   RuntimeUpdateTasks _updateTasks = const [];
   DateTime? _startTime;
   _CompiledRuntimePlan? _lastCompiledRuntimePlan;
-  Future<void> _coldStartPersistChain = Future<void>.value();
+  _CompiledRuntimePlan? _pendingCompiledRuntimePlan;
+  _ColdStartPersistenceRequest? _pendingColdStartPersistence;
+  _ColdStartPersistenceRequest? _lastPersistedColdStartPersistence;
+  Future<void>? _coldStartPersistWorker;
+  final List<Completer<void>> _coldStartPersistWaiters = [];
 
   EngineAdapter get _adapter => _activeRuntime.engine.adapter;
 
@@ -204,8 +239,10 @@ class EngineManager {
     return true;
   }
 
-  Future<void> notifyProxySelected(String groupName, String proxyName) =>
-      _adapter.notifyProxySelected(groupName, proxyName);
+  Future<void> notifyProxySelected(String groupName, String proxyName) async {
+    _syncCachedRuntimePlanWithProxySelection(groupName, proxyName);
+    await _adapter.notifyProxySelected(groupName, proxyName);
+  }
 
   Future<void> stop() async {
     Object? error;
@@ -273,9 +310,7 @@ class EngineManager {
     _syncCachedRuntimePlanWithUpdate(resolvedUpdateParams);
 
     if (coldStartPatchConfig != null) {
-      _persistColdStartInBackground(
-        coldStartPatchConfig: coldStartPatchConfig,
-      );
+      _persistColdStartInBackground(coldStartPatchConfig: coldStartPatchConfig);
     }
 
     return true;
@@ -304,6 +339,7 @@ class EngineManager {
     }
 
     if (!setupRuntimePlan) {
+      _pendingCompiledRuntimePlan = compiledRuntimePlan;
       return true;
     }
 
@@ -348,21 +384,13 @@ class EngineManager {
   }
 
   Future<void> persistColdStart({required ClashConfig pathConfig}) async {
-    final compiledRuntimePlan = _lastCompiledRuntimePlan;
     try {
-      await _enqueueColdStartPersistence(() async {
-        if (compiledRuntimePlan == null) {
-          await _persistColdStartWithoutCompiledRuntimePlan(
-            coldStartPatchConfig: pathConfig,
-          );
-          return;
-        }
-
-        await _persistColdStartFromCompiledRuntimePlan(
-          compiledRuntimePlan,
-          coldStartPatchConfig: pathConfig,
-        );
-      });
+      await _enqueueColdStartPersistence(
+        _ColdStartPersistenceRequest(
+          compiledRuntimePlan: _lastCompiledRuntimePlan,
+          patchConfig: pathConfig,
+        ),
+      );
     } catch (e) {
       commonPrint.log("persistColdStartParams: $e");
     }
@@ -430,7 +458,18 @@ class EngineManager {
   ) async {
     await request.refreshProfile?.call();
 
+    performanceCounters.rawProfileLoads++;
     final rawProfile = await _loadCurrentRawProfile();
+    final pending = _pendingCompiledRuntimePlan;
+    if (pending != null &&
+        pending.requestedPatchConfig == request.patchConfig &&
+        pending.settingsRevision == request.settingsRevision &&
+        _sameRawProfileRevision(pending.rawProfile, rawProfile)) {
+      performanceCounters.verifiedPlanReuses++;
+      return pending;
+    }
+
+    performanceCounters.profileCompilations++;
     final compiledProfile = _compileProfilePatch(
       rawProfile: rawProfile,
       patchConfig: request.patchConfig,
@@ -451,6 +490,7 @@ class EngineManager {
       return null;
     }
 
+    performanceCounters.runtimePlanBuilds++;
     final runtimePlan = await _buildRuntimePlan(
       rawProfile: rawProfile,
       securedProfile: securedProfile,
@@ -466,7 +506,19 @@ class EngineManager {
       resolvedRuntime: resolvedRuntime,
       rawProfile: rawProfile,
       securedProfile: securedProfile,
+      requestedPatchConfig: request.patchConfig,
+      settingsRevision: request.settingsRevision,
     );
+  }
+
+  bool _sameRawProfileRevision(RawProfile? left, RawProfile? right) {
+    if (left == null || right == null) return left == right;
+    final leftRevision = left.revision;
+    final rightRevision = right.revision;
+    if (leftRevision != null || rightRevision != null) {
+      return leftRevision == rightRevision;
+    }
+    return identical(left, right);
   }
 
   Future<ClashConfig?> _resolvePatchConfig(
@@ -519,44 +571,86 @@ class EngineManager {
 
     _activeRuntime = compiledRuntimePlan.resolvedRuntime;
     _lastCompiledRuntimePlan = compiledRuntimePlan;
+    if (identical(_pendingCompiledRuntimePlan, compiledRuntimePlan)) {
+      _pendingCompiledRuntimePlan = null;
+    }
     _applyRuntimePlan(compiledRuntimePlan.appliedRuntimePlan.runtimePlan);
 
     if (coldStartPatchConfig != null) {
-      _persistColdStartInBackground(
-        coldStartPatchConfig: coldStartPatchConfig,
-      );
+      _persistColdStartInBackground(coldStartPatchConfig: coldStartPatchConfig);
     }
   }
 
   void _persistColdStartInBackground({
     required ClashConfig coldStartPatchConfig,
   }) {
-    final compiledRuntimePlan = _lastCompiledRuntimePlan;
     unawaited(
-      _enqueueColdStartPersistence(() async {
-        if (compiledRuntimePlan == null) {
-          await _persistColdStartWithoutCompiledRuntimePlan(
-            coldStartPatchConfig: coldStartPatchConfig,
-          );
-          return;
-        }
-
-        await _persistColdStartFromCompiledRuntimePlan(
-          compiledRuntimePlan,
-          coldStartPatchConfig: coldStartPatchConfig,
-        );
-      }).catchError((Object error) {
+      _enqueueColdStartPersistence(
+        _ColdStartPersistenceRequest(
+          compiledRuntimePlan: _lastCompiledRuntimePlan,
+          patchConfig: coldStartPatchConfig,
+        ),
+      ).catchError((Object error) {
         commonPrint.log("persistColdStartParams: $error");
       }),
     );
   }
 
   Future<void> _enqueueColdStartPersistence(
-    Future<void> Function() persistTask,
+    _ColdStartPersistenceRequest request,
   ) {
-    final queuedTask = _coldStartPersistChain.then((_) => persistTask());
-    _coldStartPersistChain = queuedTask.catchError((_) {});
-    return queuedTask;
+    if (_pendingColdStartPersistence != null) {
+      performanceCounters.coldStartRequestsCoalesced++;
+    }
+    _pendingColdStartPersistence = request;
+    final completer = Completer<void>();
+    _coldStartPersistWaiters.add(completer);
+    _coldStartPersistWorker ??= Future<void>.microtask(
+      _drainColdStartPersistence,
+    );
+    return completer.future;
+  }
+
+  Future<void> _drainColdStartPersistence() async {
+    Object? failure;
+    StackTrace? failureStackTrace;
+    while (_pendingColdStartPersistence != null) {
+      final request = _pendingColdStartPersistence!;
+      _pendingColdStartPersistence = null;
+      final last = _lastPersistedColdStartPersistence;
+      if (last != null && request.sameSnapshotAs(last)) {
+        performanceCounters.coldStartSnapshotsSkipped++;
+        continue;
+      }
+      try {
+        final compiledRuntimePlan = request.compiledRuntimePlan;
+        if (compiledRuntimePlan == null) {
+          await _persistColdStartWithoutCompiledRuntimePlan(
+            coldStartPatchConfig: request.patchConfig,
+          );
+        } else {
+          await _persistColdStartFromCompiledRuntimePlan(
+            compiledRuntimePlan,
+            coldStartPatchConfig: request.patchConfig,
+          );
+        }
+        _lastPersistedColdStartPersistence = request;
+      } catch (error, stackTrace) {
+        failure ??= error;
+        failureStackTrace ??= stackTrace;
+      }
+    }
+
+    final waiters = List<Completer<void>>.from(_coldStartPersistWaiters);
+    _coldStartPersistWaiters.clear();
+    _coldStartPersistWorker = null;
+    for (final waiter in waiters) {
+      if (failure == null) {
+        waiter.complete();
+      } else {
+        waiter.completeError(failure, failureStackTrace);
+      }
+    }
   }
 
   Future<void> _persistColdStartFromCompiledRuntimePlan(
@@ -567,23 +661,12 @@ class EngineManager {
       runtimePatchConfig: compiledRuntimePlan.appliedRuntimePlan.patchConfig,
       coldStartPatchConfig: coldStartPatchConfig,
     );
-    final coldStartSecuredProfile = SecuredProfilePatch(
-      patchConfig: resolvedColdStartPatchConfig,
-      metadata: compiledRuntimePlan.securedProfile.metadata,
-      runtimeConstraints: _resolveColdStartRuntimeConstraints(
-        runtimeConstraints:
-            compiledRuntimePlan.securedProfile.runtimeConstraints,
-        coldStartPatchConfig: resolvedColdStartPatchConfig,
-      ),
+    performanceCounters.coldStartPlanDerivations++;
+    final coldStartRuntimePlan = _deriveColdStartRuntimePlan(
+      compiledRuntimePlan.appliedRuntimePlan.runtimePlan,
+      resolvedColdStartPatchConfig,
     );
-    final coldStartRuntimePlan = await _buildRuntimePlan(
-      rawProfile: compiledRuntimePlan.rawProfile,
-      securedProfile: coldStartSecuredProfile,
-      runtimePatchConfig: resolvedColdStartPatchConfig,
-    );
-    final resolvedRuntime =
-        _resolveRuntimeSelection(coldStartRuntimePlan.runtime);
-    await resolvedRuntime.engine.adapter.persistColdStart(
+    await compiledRuntimePlan.resolvedRuntime.engine.adapter.persistColdStart(
       initParams: await _buildInitParams(),
       runtimePlan: coldStartRuntimePlan,
       state: _buildCoreState(
@@ -595,6 +678,7 @@ class EngineManager {
   Future<void> _persistColdStartWithoutCompiledRuntimePlan({
     required ClashConfig coldStartPatchConfig,
   }) async {
+    performanceCounters.runtimePlanBuilds++;
     final coldStartRuntimePlan = await _buildRuntimePlan(
       rawProfile: null,
       securedProfile: SecuredProfilePatch(
@@ -603,8 +687,9 @@ class EngineManager {
       ),
       runtimePatchConfig: coldStartPatchConfig,
     );
-    final resolvedRuntime =
-        _resolveRuntimeSelection(coldStartRuntimePlan.runtime);
+    final resolvedRuntime = _resolveRuntimeSelection(
+      coldStartRuntimePlan.runtime,
+    );
     await resolvedRuntime.engine.adapter.persistColdStart(
       initParams: await _buildInitParams(),
       runtimePlan: coldStartRuntimePlan,
@@ -620,13 +705,30 @@ class EngineManager {
   }) =>
       runtimePatchConfig.copyWith.tun(enable: coldStartPatchConfig.tun.enable);
 
-  RuntimeSecurityConstraints _resolveColdStartRuntimeConstraints({
-    required RuntimeSecurityConstraints runtimeConstraints,
-    required ClashConfig coldStartPatchConfig,
-  }) =>
-      coldStartPatchConfig.tun.enable
-          ? runtimeConstraints
-          : const RuntimeSecurityConstraints();
+  RuntimePlan _deriveColdStartRuntimePlan(
+    RuntimePlan runtimePlan,
+    ClashConfig coldStartPatchConfig,
+  ) {
+    final config = Map<String, dynamic>.from(runtimePlan.config);
+    final tun = switch (config['tun']) {
+      final Map<dynamic, dynamic> value => <String, dynamic>{
+          for (final entry in value.entries) entry.key.toString(): entry.value,
+        },
+      _ => <String, dynamic>{},
+    };
+    tun['enable'] = coldStartPatchConfig.tun.enable;
+    config['tun'] = tun;
+    return RuntimePlan(
+      config: config,
+      selectedMap: runtimePlan.selectedMap,
+      testUrl: runtimePlan.testUrl,
+      runtime: runtimePlan.runtime,
+      files: runtimePlan.files,
+      builtInProxyNodes: runtimePlan.builtInProxyNodes,
+      metadata: runtimePlan.metadata,
+      profileAccessControl: runtimePlan.profileAccessControl,
+    );
+  }
 
   void _syncCachedRuntimePlanWithUpdate(UpdateParams updateParams) {
     final compiledRuntimePlan = _lastCompiledRuntimePlan;
@@ -659,6 +761,42 @@ class EngineManager {
         runtimeConstraints:
             compiledRuntimePlan.securedProfile.runtimeConstraints,
       ),
+      requestedPatchConfig: updatedPatchConfig,
+      settingsRevision: compiledRuntimePlan.settingsRevision,
+    );
+  }
+
+  void _syncCachedRuntimePlanWithProxySelection(
+    String groupName,
+    String proxyName,
+  ) {
+    final compiled = _lastCompiledRuntimePlan;
+    if (compiled == null ||
+        compiled.appliedRuntimePlan.runtimePlan.selectedMap[groupName] ==
+            proxyName) {
+      return;
+    }
+    final currentPlan = compiled.appliedRuntimePlan.runtimePlan;
+    final updatedPlan = RuntimePlan(
+      config: currentPlan.config,
+      selectedMap: {...currentPlan.selectedMap, groupName: proxyName},
+      testUrl: currentPlan.testUrl,
+      runtime: currentPlan.runtime,
+      files: currentPlan.files,
+      builtInProxyNodes: currentPlan.builtInProxyNodes,
+      metadata: currentPlan.metadata,
+      profileAccessControl: currentPlan.profileAccessControl,
+    );
+    _lastCompiledRuntimePlan = _CompiledRuntimePlan(
+      appliedRuntimePlan: AppliedRuntimePlan(
+        patchConfig: compiled.appliedRuntimePlan.patchConfig,
+        runtimePlan: updatedPlan,
+      ),
+      resolvedRuntime: compiled.resolvedRuntime,
+      rawProfile: compiled.rawProfile,
+      securedProfile: compiled.securedProfile,
+      requestedPatchConfig: compiled.requestedPatchConfig,
+      settingsRevision: compiled.settingsRevision,
     );
   }
 
@@ -700,14 +838,12 @@ class EngineManager {
     UpdateParams updateParams,
   ) {
     final updatedConfig = Map<String, dynamic>.from(config);
-    final updatedTun = Map<String, dynamic>.from(
-      switch (updatedConfig['tun']) {
-        final Map<dynamic, dynamic> tun => tun.map(
-            (key, value) => MapEntry(key.toString(), value),
-          ),
-        _ => const <String, dynamic>{},
-      },
-    );
+    final updatedTun = Map<String, dynamic>.from(switch (updatedConfig['tun']) {
+      final Map<dynamic, dynamic> tun => tun.map(
+          (key, value) => MapEntry(key.toString(), value),
+        ),
+      _ => const <String, dynamic>{},
+    });
 
     updatedTun['enable'] = updateParams.tun.enable;
     updatedTun['device'] = updateParams.tun.device;
@@ -747,7 +883,8 @@ class EngineManager {
             );
 
   ResolvedRuntimeSelection _resolveRuntimeSelection(
-      RuntimeSelection selection) {
+    RuntimeSelection selection,
+  ) {
     if (_activeRuntime.selection == selection) {
       return _activeRuntime;
     }

--- a/lib/product/runtime/engine_manager.dart
+++ b/lib/product/runtime/engine_manager.dart
@@ -571,9 +571,9 @@ class EngineManager {
 
     _activeRuntime = compiledRuntimePlan.resolvedRuntime;
     _lastCompiledRuntimePlan = compiledRuntimePlan;
-    if (identical(_pendingCompiledRuntimePlan, compiledRuntimePlan)) {
-      _pendingCompiledRuntimePlan = null;
-    }
+    // Once any plan is applied, an older init-only candidate must never become
+    // reusable again if settings later happen to match its old revision.
+    _pendingCompiledRuntimePlan = null;
     _applyRuntimePlan(compiledRuntimePlan.appliedRuntimePlan.runtimePlan);
 
     if (coldStartPatchConfig != null) {

--- a/lib/product/runtime/local_node_controller.dart
+++ b/lib/product/runtime/local_node_controller.dart
@@ -98,8 +98,19 @@ abstract class LocalNodeController<
   LocalNodeStageState<TNodeLayout>? _stagedState;
   Future<TSharedLayout>? _sharedLayout;
 
-  Future<TSharedLayout> _resolveSharedLayout() =>
-      _sharedLayout ??= binary.resolveSharedInstallLayout();
+  Future<TSharedLayout> _resolveSharedLayout() async {
+    final cached = _sharedLayout;
+    if (cached != null) return cached;
+
+    final task = binary.resolveSharedInstallLayout();
+    _sharedLayout = task;
+    try {
+      return await task;
+    } catch (_) {
+      if (identical(_sharedLayout, task)) _sharedLayout = null;
+      rethrow;
+    }
+  }
 
   Future<String> stageRuntimePlan({
     required List<BuiltInProxyNodePlan> currentPlans,

--- a/lib/product/runtime/local_node_controller.dart
+++ b/lib/product/runtime/local_node_controller.dart
@@ -96,6 +96,10 @@ abstract class LocalNodeController<
   final RuntimeNodePlatformBridge runtime;
 
   LocalNodeStageState<TNodeLayout>? _stagedState;
+  Future<TSharedLayout>? _sharedLayout;
+
+  Future<TSharedLayout> _resolveSharedLayout() =>
+      _sharedLayout ??= binary.resolveSharedInstallLayout();
 
   Future<String> stageRuntimePlan({
     required List<BuiltInProxyNodePlan> currentPlans,
@@ -104,8 +108,11 @@ abstract class LocalNodeController<
     if (_stagedState != null) {
       return '$typeLabel runtime plan stage is already active.';
     }
+    if (currentPlans.isEmpty && nextPlans.isEmpty) {
+      return '';
+    }
 
-    final sharedLayout = await binary.resolveSharedInstallLayout();
+    final sharedLayout = await _resolveSharedLayout();
     await Directory(sharedLayout.runtimeRootPath).create(recursive: true);
     await Directory(sharedLayout.nodesDirectoryPath).create(recursive: true);
     final nextIds = nextPlans.map((plan) => plan.nodeId).toSet();
@@ -163,7 +170,7 @@ abstract class LocalNodeController<
     if (stagedState == null) return;
     _stagedState = null;
     try {
-      final sharedLayout = await binary.resolveSharedInstallLayout();
+      final sharedLayout = await _resolveSharedLayout();
       await Future.wait([
         for (final removedPlan in stagedState.removedPlans)
           deleteDirectoryIfExists(
@@ -185,7 +192,7 @@ abstract class LocalNodeController<
     List<BuiltInProxyNodePlan> plans,
   ) async {
     if (plans.isEmpty) return const [];
-    final sharedLayout = await binary.resolveSharedInstallLayout();
+    final sharedLayout = await _resolveSharedLayout();
     return Future.wait([
       for (final plan in plans)
         _buildRuntimeNode(sharedLayout: sharedLayout, plan: plan),

--- a/lib/product/services/access_control_service.dart
+++ b/lib/product/services/access_control_service.dart
@@ -122,6 +122,26 @@ typedef LoadCurrentRawProfile = Future<RawProfile?> Function();
 typedef ReadProfilesPath = Future<String> Function();
 typedef ReadInstalledPackageNames = Future<List<String>> Function();
 
+@immutable
+class AccessPackageKeys {
+  const AccessPackageKeys({
+    required this.label,
+    required this.packageName,
+    required this.pinyin,
+  });
+
+  final String label;
+  final String packageName;
+  final String pinyin;
+}
+
+@immutable
+class AccessPackageIndex {
+  const AccessPackageIndex(this.keysByPackageName);
+
+  final Map<String, AccessPackageKeys> keysByPackageName;
+}
+
 class ProfileManagedAccessController {
   ProfileManagedAccessController({
     required this.service,
@@ -273,10 +293,13 @@ class AccessControlService {
   List<Package> filterPackages({
     required List<Package> packages,
     required AccessControlEditorState editorState,
+    AccessPackageIndex? index,
   }) {
     final query = editorState.query.toLowerCase();
     final selectedPackages = editorState.selectedPackages;
+    final resolvedIndex = index ?? buildPackageIndex(packages);
     final filtered = packages.where((package) {
+      final keys = resolvedIndex.keysByPackageName[package.packageName]!;
       if (!editorState.showSystemApps && package.system) {
         return false;
       }
@@ -284,8 +307,8 @@ class AccessControlService {
         return false;
       }
       if (query.isNotEmpty &&
-          !package.label.toLowerCase().contains(query) &&
-          !package.packageName.toLowerCase().contains(query)) {
+          !keys.label.contains(query) &&
+          !keys.packageName.contains(query)) {
         return false;
       }
       return true;
@@ -298,17 +321,36 @@ class AccessControlService {
         if (selectedA != selectedB) {
           return selectedA ? -1 : 1;
         }
-        return _comparePackages(a, b, editorState.sort);
+        return _comparePackages(a, b, editorState.sort, resolvedIndex);
       });
   }
 
-  int _comparePackages(Package a, Package b, AccessSortType sort) =>
+  AccessPackageIndex buildPackageIndex(List<Package> packages) =>
+      AccessPackageIndex(
+        Map<String, AccessPackageKeys>.unmodifiable({
+          for (final package in packages)
+            package.packageName: AccessPackageKeys(
+              label: package.label.toLowerCase(),
+              packageName: package.packageName.toLowerCase(),
+              pinyin: utils.getPinyin(package.label),
+            ),
+        }),
+      );
+
+  int _comparePackages(
+    Package a,
+    Package b,
+    AccessSortType sort,
+    AccessPackageIndex index,
+  ) =>
       switch (sort) {
         AccessSortType.none =>
-          a.label.toLowerCase().compareTo(b.label.toLowerCase()),
+          index.keysByPackageName[a.packageName]!.label.compareTo(
+            index.keysByPackageName[b.packageName]!.label,
+          ),
         AccessSortType.name => utils.sortByChar(
-            utils.getPinyin(a.label),
-            utils.getPinyin(b.label),
+            index.keysByPackageName[a.packageName]!.pinyin,
+            index.keysByPackageName[b.packageName]!.pinyin,
           ),
         AccessSortType.time => b.lastUpdateTime.compareTo(a.lastUpdateTime),
       };

--- a/lib/product/services/android_shell_service.dart
+++ b/lib/product/services/android_shell_service.dart
@@ -15,6 +15,7 @@ class AndroidShellService {
   final AndroidShellPlatformBridge platform;
   final AndroidForegroundNotificationPolicy foregroundNotification;
   String? _lastForegroundNotificationTitle;
+  Future<void> _foregroundNotificationPush = Future<void>.value();
 
   void bindTileCommands({
     AndroidTileStartHandler? onStart,
@@ -68,12 +69,16 @@ class AndroidShellService {
   }) =>
       foregroundNotification.buildTitle(profile, groups: groups);
 
-  Future<void> pushForegroundNotificationTitle(String title) async {
-    if (title.isEmpty || title == _lastForegroundNotificationTitle) {
-      return;
-    }
-    await platform.pushForegroundNotificationTitle(title);
-    _lastForegroundNotificationTitle = title;
+  Future<void> pushForegroundNotificationTitle(String title) {
+    if (title.isEmpty) return Future<void>.value();
+
+    final task = _foregroundNotificationPush.then((_) async {
+      if (title == _lastForegroundNotificationTitle) return;
+      await platform.pushForegroundNotificationTitle(title);
+      _lastForegroundNotificationTitle = title;
+    });
+    _foregroundNotificationPush = task.catchError((_) {});
+    return task;
   }
 
   Future<void> syncForegroundNotification({

--- a/lib/product/services/android_shell_service.dart
+++ b/lib/product/services/android_shell_service.dart
@@ -7,13 +7,14 @@ import '../android/android_foreground_notification_policy.dart';
 import '../android/android_shell_bridge.dart';
 
 class AndroidShellService {
-  const AndroidShellService({
-    this.platform = const AndroidShellBridge(),
+  AndroidShellService({
+    AndroidShellPlatformBridge? platform,
     this.foregroundNotification = const AndroidForegroundNotificationPolicy(),
-  });
+  }) : platform = platform ?? const AndroidShellBridge();
 
   final AndroidShellPlatformBridge platform;
   final AndroidForegroundNotificationPolicy foregroundNotification;
+  String? _lastForegroundNotificationTitle;
 
   void bindTileCommands({
     AndroidTileStartHandler? onStart,
@@ -67,8 +68,13 @@ class AndroidShellService {
   }) =>
       foregroundNotification.buildTitle(profile, groups: groups);
 
-  Future<void> pushForegroundNotificationTitle(String title) =>
-      platform.pushForegroundNotificationTitle(title);
+  Future<void> pushForegroundNotificationTitle(String title) async {
+    if (title.isEmpty || title == _lastForegroundNotificationTitle) {
+      return;
+    }
+    await platform.pushForegroundNotificationTitle(title);
+    _lastForegroundNotificationTitle = title;
+  }
 
   Future<void> syncForegroundNotification({
     required Profile? profile,

--- a/lib/product/services/app_update_service.dart
+++ b/lib/product/services/app_update_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../common/common.dart';
 import '../android/android_update_bridge.dart';
@@ -18,12 +19,47 @@ enum AppUpdateCheckTrigger {
 
 typedef SkipAppUpdateRelease = Future<void> Function(String tagName);
 
+abstract interface class AutomaticUpdateCheckStore {
+  Future<DateTime?> readLastAttempt();
+
+  Future<void> writeLastAttempt(DateTime value);
+}
+
+class SharedPreferencesAutomaticUpdateCheckStore
+    implements AutomaticUpdateCheckStore {
+  const SharedPreferencesAutomaticUpdateCheckStore();
+
+  static const _key = 'flclashm.lastAutomaticUpdateCheckMillis';
+
+  @override
+  Future<DateTime?> readLastAttempt() async {
+    final millis = (await SharedPreferences.getInstance()).getInt(_key);
+    return millis == null ? null : DateTime.fromMillisecondsSinceEpoch(millis);
+  }
+
+  @override
+  Future<void> writeLastAttempt(DateTime value) async {
+    await (await SharedPreferences.getInstance()).setInt(
+      _key,
+      value.millisecondsSinceEpoch,
+    );
+  }
+}
+
 class AppUpdateService {
-  const AppUpdateService({
+  AppUpdateService({
     this.platform = const AndroidUpdateBridge(),
-  });
+    AutomaticUpdateCheckStore? automaticCheckStore,
+    DateTime Function()? now,
+    this.automaticCheckInterval = const Duration(hours: 12),
+  })  : automaticCheckStore = automaticCheckStore ??
+            const SharedPreferencesAutomaticUpdateCheckStore(),
+        now = now ?? DateTime.now;
 
   final AppUpdatePlatformBridge platform;
+  final AutomaticUpdateCheckStore automaticCheckStore;
+  final DateTime Function() now;
+  final Duration automaticCheckInterval;
 
   Future<void> autoCheck({
     required bool enabled,
@@ -34,6 +70,15 @@ class AppUpdateService {
     if (!enabled) {
       return;
     }
+    final attemptTime = now();
+    final lastAttempt = await automaticCheckStore.readLastAttempt();
+    if (lastAttempt != null) {
+      final age = attemptTime.difference(lastAttempt);
+      if (!age.isNegative && age < automaticCheckInterval) return;
+    }
+    // Persist before network I/O so repeated UI opens while offline do not
+    // restart the same multi-request check indefinitely.
+    await automaticCheckStore.writeLastAttempt(attemptTime);
 
     final release = await platform.checkForAppUpdate(
       includePrerelease: includePrerelease,

--- a/lib/product/services/product_services.dart
+++ b/lib/product/services/product_services.dart
@@ -9,15 +9,16 @@ export 'app_update_service.dart';
 export 'product_contributors.dart';
 
 class ProductServices {
-  const ProductServices({
+  ProductServices({
     this.accessControl = const AccessControlService(),
-    this.androidShell = const AndroidShellService(),
-    this.appUpdate = const AppUpdateService(),
-  });
+    AndroidShellService? androidShell,
+    AppUpdateService? appUpdate,
+  })  : androidShell = androidShell ?? AndroidShellService(),
+        appUpdate = appUpdate ?? AppUpdateService();
 
   final AccessControlService accessControl;
   final AndroidShellService androidShell;
   final AppUpdateService appUpdate;
 }
 
-const productServices = ProductServices();
+final productServices = ProductServices();

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi' show Pointer;
-import 'dart:io' show Platform;
+import 'dart:io' show File, Platform;
 
 import 'package:animations/animations.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -17,7 +17,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_js/flutter_js.dart';
 import 'package:material_color_utilities/palettes/core_palette.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:path/path.dart' as p;
 import 'package:url_launcher/url_launcher.dart';
 
 import 'common/common.dart';
@@ -110,6 +109,7 @@ class GlobalState {
   late Config config;
   late AppState appState;
   bool isPre = true;
+  Future<void> corePreload = Future<void>.value();
   String? coreSHA256;
   String? coreVersion;
   // Full release version baked in at build time via --dart-define=APP_VERSION
@@ -125,6 +125,7 @@ class GlobalState {
   Map<String, dynamic>? lastRuntimeConfig;
   final activeProfileAccessControlNotifier =
       ValueNotifier<AccessControl?>(null);
+  final _loadedProfiles = LoadedProfileRepository();
   // Effective external-controller endpoint after applying the advisory/profile
   // merge rules for the active profile. Empty string means disabled.
   final effectiveExternalController = ValueNotifier<String>("");
@@ -215,11 +216,11 @@ class GlobalState {
       traffics: FixedList(30),
       totalTraffic: Traffic(),
     );
-    await _initDynamicColor();
+    accentColor = const Color(defaultPrimaryColor);
     await init();
   }
 
-  Future<void> _initDynamicColor() async {
+  Future<void> loadDynamicColor() async {
     try {
       corePalette = await DynamicColorPlugin.getCorePalette();
       accentColor = await DynamicColorPlugin.getAccentColor() ??
@@ -228,9 +229,10 @@ class GlobalState {
   }
 
   Future<void> init() async {
-    packageInfo = await PackageInfo.fromPlatform();
-    config = await preferences.getConfig() ??
-        const Config(themeProps: defaultThemeProps);
+    final packageInfoFuture = PackageInfo.fromPlatform();
+    final configFuture = preferences.getConfig();
+    packageInfo = await packageInfoFuture;
+    config = await configFuture ?? const Config(themeProps: defaultThemeProps);
     await globalState.migrateOldData(config);
     await AppLocalizations.load(
       utils.getLocaleForString(config.appSetting.locale) ??
@@ -378,17 +380,37 @@ class GlobalState {
   Future<RawProfile?> loadCurrentRawProfile() async {
     final profile = config.currentProfile;
     if (profile == null) {
+      _loadedProfiles.clear();
       return null;
     }
     final profilePath = await appPath.getProfilePath(profile.id);
-    final rawConfig = await handleEvaluate(
-      await loadProfileConfigFromFile(profilePath),
-    );
-    return RawProfile.fromConfig(
+    final profileStat = await File(profilePath).stat();
+    final currentScript = config.scriptProps.currentScript;
+    final revision = RawProfileRevision(
       profile: profile,
-      config: rawConfig,
+      lastModifiedMicros: profileStat.modified.microsecondsSinceEpoch,
+      fileSize: profileStat.size,
+      scriptId: currentScript?.id,
+      scriptContent: currentScript?.content,
     );
+    return _loadedProfiles.load(revision, () async {
+      final rawConfig = await handleEvaluate(
+        await loadProfileConfigFromFile(profilePath),
+      );
+      return RawProfile.fromConfig(
+        profile: profile,
+        config: rawConfig,
+        revision: revision,
+      );
+    });
   }
+
+  Object get runtimePlanSettingsRevision => (
+        config.appSetting.overrideNetworkSettings,
+        config.overrideDns,
+        config.networkProps.routeMode,
+        config.appSetting.testUrl,
+      );
 
   CompiledProfilePatch compileProfilePatch({
     required RawProfile? rawProfile,
@@ -603,18 +625,22 @@ class GlobalState {
     }
     final configJs = json.encode(config);
     final runtime = getJavascriptRuntime();
-    final res = await runtime.evaluateAsync("""
-      ${currentScript.content}
-      main($configJs)
-    """);
-    if (res.isError) {
-      throw res.stringResult;
+    try {
+      final res = await runtime.evaluateAsync("""
+        ${currentScript.content}
+        main($configJs)
+      """);
+      if (res.isError) {
+        throw res.stringResult;
+      }
+      final value = switch (res.rawResult is Pointer) {
+        true => runtime.convertValue<Map<String, dynamic>>(res),
+        false => Map<String, dynamic>.from(res.rawResult),
+      };
+      return value ?? config;
+    } finally {
+      runtime.dispose();
     }
-    final value = switch (res.rawResult is Pointer) {
-      true => runtime.convertValue<Map<String, dynamic>>(res),
-      false => Map<String, dynamic>.from(res.rawResult),
-    };
-    return value ?? config;
   }
 }
 

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -410,6 +410,7 @@ class GlobalState {
         config.overrideDns,
         config.networkProps.routeMode,
         config.appSetting.testUrl,
+        json.encode(config.currentProfile?.selectedMap ?? const {}),
       );
 
   CompiledProfilePatch compileProfilePatch({

--- a/lib/views/access.dart
+++ b/lib/views/access.dart
@@ -30,6 +30,9 @@ class _AccessViewState extends ConsumerState<AccessView> {
   ProfileManagedAccessNotice _notice = ProfileManagedAccessNotice.none;
   bool _isTV = false;
   bool _searchEditing = false;
+  Timer? _searchDebounce;
+  List<Package>? _indexedPackages;
+  AccessPackageIndex? _packageIndex;
 
   @override
   void initState() {
@@ -89,6 +92,7 @@ class _AccessViewState extends ConsumerState<AccessView> {
     _searchFocusNode.removeListener(_onSearchFocusChange);
     _searchFocusNode.dispose();
     _searchController.dispose();
+    _searchDebounce?.cancel();
     _scrollController.dispose();
     super.dispose();
   }
@@ -199,9 +203,14 @@ class _AccessViewState extends ConsumerState<AccessView> {
         (_, __) => unawaited(_refreshManagedAccess()),
       );
     final packages = ref.watch(packagesProvider);
+    if (!identical(packages, _indexedPackages)) {
+      _indexedPackages = packages;
+      _packageIndex = productServices.accessControl.buildPackageIndex(packages);
+    }
     final filtered = productServices.accessControl.filterPackages(
       packages: packages,
       editorState: _editorState,
+      index: _packageIndex,
     );
     final appLocale = AppLocalizations.of(context);
     final isWhitelist = _editorState.isWhitelist;
@@ -298,6 +307,7 @@ class _AccessViewState extends ConsumerState<AccessView> {
                             ? IconButton(
                                 icon: const Icon(Icons.clear, size: 18),
                                 onPressed: () {
+                                  _searchDebounce?.cancel();
                                   _searchController.clear();
                                   setState(() {
                                     _editorState =
@@ -310,12 +320,19 @@ class _AccessViewState extends ConsumerState<AccessView> {
                               )
                             : null,
                       ),
-                      onChanged: (v) => setState(() {
-                        _editorState = productServices.accessControl.setQuery(
-                          _editorState,
-                          v,
+                      onChanged: (value) {
+                        _searchDebounce?.cancel();
+                        _searchDebounce = Timer(
+                          const Duration(milliseconds: 180),
+                          () {
+                            if (!mounted) return;
+                            setState(() {
+                              _editorState = productServices.accessControl
+                                  .setQuery(_editorState, value);
+                            });
+                          },
                         );
-                      }),
+                      },
                     ),
                   ),
                   Padding(

--- a/lib/views/profiles/profiles.dart
+++ b/lib/views/profiles/profiles.dart
@@ -203,10 +203,12 @@ class _ProfileItemState extends State<ProfileItem> {
   final FocusNode _menuFocusNode = FocusNode();
   bool _isMenuFocused = false;
   bool _isTV = false;
+  late ProductDisplayHints _displayHints;
 
   @override
   void initState() {
     super.initState();
+    _displayHints = ProductProviderAdvisory.fromProfile(widget.profile).display;
     _checkIfTV();
     _menuFocusNode.addListener(() {
       if (mounted) {
@@ -215,6 +217,15 @@ class _ProfileItemState extends State<ProfileItem> {
         });
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant ProfileItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.profile != widget.profile) {
+      _displayHints =
+          ProductProviderAdvisory.fromProfile(widget.profile).display;
+    }
   }
 
   Future<void> _checkIfTV() async {
@@ -389,8 +400,7 @@ class _ProfileItemState extends State<ProfileItem> {
 
   @override
   Widget build(BuildContext context) {
-    final displayHints =
-        ProductProviderAdvisory.fromProfile(widget.profile).display;
+    final displayHints = _displayHints;
     return CommonCard(
       isSelected: widget.profile.id == widget.groupValue,
       onPressed: _isTV

--- a/test/product/bootstrap/startup_sequence_contract_test.dart
+++ b/test/product/bootstrap/startup_sequence_contract_test.dart
@@ -9,12 +9,13 @@ void main() {
     controller = await File('lib/controller.dart').readAsString();
   });
 
-  test('finishes node preparation before optional startup maintenance', () {
-    final preload = controller.indexOf('await _preloadClashConfig();');
+  test('exposes UI readiness while node preparation continues', () {
+    final preload = controller.indexOf('preload = _preloadClashConfig();');
     final ready = controller.indexOf(
       '_ref.read(initProvider.notifier).value = true;',
       preload,
     );
+    final detachedPreload = controller.indexOf('unawaited(preload);', ready);
     final maintenance = controller.indexOf(
       'unawaited(_runStartupMaintenance());',
       ready,
@@ -22,6 +23,7 @@ void main() {
 
     expect(preload, greaterThan(0));
     expect(ready, greaterThan(preload));
+    expect(detachedPreload, greaterThan(ready));
     expect(maintenance, greaterThan(ready));
   });
 

--- a/test/product/compile/config_tree_test.dart
+++ b/test/product/compile/config_tree_test.dart
@@ -21,4 +21,25 @@ void main() {
         1);
     expect(copiedItems[1], same(marker));
   });
+
+  test('freezes every source profile container', () {
+    final frozen = freezeConfigTree({
+      'nested': {
+        'items': [
+          {'value': 1},
+        ],
+      },
+    });
+
+    expect(() => frozen['new'] = true, throwsUnsupportedError);
+    expect(
+      () => ((frozen['nested'] as Map)['items'] as List).add(2),
+      throwsUnsupportedError,
+    );
+    expect(
+      () => ((((frozen['nested'] as Map)['items'] as List).first
+          as Map)['value'] = 2),
+      throwsUnsupportedError,
+    );
+  });
 }

--- a/test/product/compile/loaded_profile_repository_test.dart
+++ b/test/product/compile/loaded_profile_repository_test.dart
@@ -97,4 +97,45 @@ void main() {
 
     expect(loadCalls, 4);
   });
+
+  test('clear does not reuse or recache an in-flight revision', () async {
+    final repository = LoadedProfileRepository();
+    const revision = RawProfileRevision(
+      profile: profile,
+      lastModifiedMicros: 10,
+      fileSize: 100,
+    );
+    final staleLoad = Completer<RawProfile>();
+    var loadCalls = 0;
+
+    final first = repository.load(revision, () {
+      loadCalls++;
+      return staleLoad.future;
+    });
+    repository.clear();
+    final fresh = repository.load(revision, () async {
+      loadCalls++;
+      return RawProfile.fromConfig(
+        profile: profile,
+        config: const {'revision': 'fresh'},
+        revision: revision,
+      );
+    });
+    staleLoad.complete(
+      RawProfile.fromConfig(
+        profile: profile,
+        config: const {'revision': 'stale'},
+        revision: revision,
+      ),
+    );
+
+    expect((await first).config['revision'], 'stale');
+    expect((await fresh).config['revision'], 'fresh');
+    expect(
+      (await repository.load(revision, () => throw StateError('unexpected')))
+          .config['revision'],
+      'fresh',
+    );
+    expect(loadCalls, 2);
+  });
 }

--- a/test/product/compile/loaded_profile_repository_test.dart
+++ b/test/product/compile/loaded_profile_repository_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flclashx/models/models.dart';
+import 'package:flclashx/product/compile/product_compile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const profile = Profile(
+    id: 'profile-cache',
+    autoUpdateDuration: Duration.zero,
+  );
+
+  test('shares YAML/script work for one complete profile revision', () async {
+    final repository = LoadedProfileRepository();
+    const revision = RawProfileRevision(
+      profile: profile,
+      lastModifiedMicros: 10,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'function main(config) { return config; }',
+    );
+    final loadCompleter = Completer<RawProfile>();
+    var loadCalls = 0;
+
+    Future<RawProfile> loader() {
+      loadCalls++;
+      return loadCompleter.future;
+    }
+
+    final first = repository.load(revision, loader);
+    final concurrent = repository.load(revision, loader);
+    loadCompleter.complete(
+      RawProfile.fromConfig(
+        profile: profile,
+        config: const {'proxies': []},
+        revision: revision,
+      ),
+    );
+    final loaded = await first;
+
+    expect(await concurrent, same(loaded));
+    expect(await repository.load(revision, loader), same(loaded));
+    expect(loadCalls, 1);
+  });
+
+  test('invalidates only on compiler-relevant profile revisions', () async {
+    final repository = LoadedProfileRepository();
+    var loadCalls = 0;
+
+    Future<RawProfile> load(RawProfileRevision revision) =>
+        repository.load(revision, () async {
+          loadCalls++;
+          return RawProfile.fromConfig(
+            profile: revision.profile,
+            config: const {'proxies': []},
+            revision: revision,
+          );
+        });
+
+    await load(const RawProfileRevision(
+      profile: profile,
+      lastModifiedMicros: 10,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'v1',
+    ));
+    await load(const RawProfileRevision(
+      profile: profile,
+      lastModifiedMicros: 11,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'v1',
+    ));
+    await load(const RawProfileRevision(
+      profile: profile,
+      lastModifiedMicros: 11,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'v2',
+    ));
+    await load(RawProfileRevision(
+      profile: profile.copyWith(selectedMap: const {'Proxy': 'Node'}),
+      lastModifiedMicros: 11,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'v2',
+    ));
+    await load(RawProfileRevision(
+      profile: profile.copyWith(
+        overrideData: const OverrideData(enable: true),
+      ),
+      lastModifiedMicros: 11,
+      fileSize: 100,
+      scriptId: 'script-1',
+      scriptContent: 'v2',
+    ));
+
+    expect(loadCalls, 4);
+  });
+}

--- a/test/product/compile/profile_compiler_test.dart
+++ b/test/product/compile/profile_compiler_test.dart
@@ -152,6 +152,54 @@ void main() {
   });
 
   group('ProfileCompiler.buildRuntimePlan', () {
+    test('validates once and mutates the compiler transaction copy', () async {
+      final builtInCompiler = _RecordingBuiltInProxyCompiler();
+      final profileCompiler = ProfileCompiler(
+        builtInProxyCompiler: builtInCompiler,
+      );
+      const profile = Profile(
+        id: 'profile-transaction',
+        autoUpdateDuration: Duration.zero,
+      );
+      final rawProfile = RawProfile.fromConfig(
+        profile: profile,
+        config: const {'proxies': []},
+      );
+      final compiled = profileCompiler.compileProfilePatch(
+        rawProfile: rawProfile,
+        context: const ProfilePatchContext(
+          patchConfig: ClashConfig(),
+          overrideNetworkSettings: true,
+        ),
+      );
+
+      await profileCompiler.buildRuntimePlan(
+        rawProfile: rawProfile,
+        context: const RuntimePlanBuildContext(
+          isAndroid: false,
+          overrideNetworkSettings: true,
+          overrideDns: false,
+          routeMode: RouteMode.config,
+          hasCurrentScript: false,
+          profilesPath: '',
+          readInstalledPackageNames: _readNoInstalledPackages,
+        ),
+        securedProfile: SecuredProfilePatch(
+          patchConfig: compiled.patchConfig,
+          metadata: compiled.metadata,
+        ),
+        runtimePatchConfig: compiled.patchConfig,
+        selectedMap: const {},
+        testUrl: 'https://example.com',
+        providerAssetPathResolver: (_, __, ___) async => '',
+      );
+
+      expect(builtInCompiler.validateCalls, 1);
+      expect(builtInCompiler.lastCompileCopiedConfig, isFalse);
+      expect(builtInCompiler.lastCompileValidated, isFalse);
+      expect(rawProfile.config, const {'proxies': []});
+    });
+
     test('writes sanitized compiled network settings into runtime config',
         () async {
       const profile = Profile(
@@ -390,7 +438,10 @@ void main() {
         ),
       )
         ..createSync(recursive: true)
-        ..writeAsStringSync('com.network.app\n');
+        ..writeAsStringSync('com.network.app\n')
+        ..setLastModifiedSync(
+          DateTime.now().subtract(const Duration(hours: 7)),
+        );
       const profile = Profile(
         id: 'profile-split-disabled',
         autoUpdateDuration: Duration.zero,
@@ -1231,3 +1282,34 @@ void main() {
 }
 
 Future<List<String>> _readNoInstalledPackages() async => const [];
+
+class _RecordingBuiltInProxyCompiler extends BuiltInProxyCompiler {
+  int validateCalls = 0;
+  bool? lastCompileCopiedConfig;
+  bool? lastCompileValidated;
+
+  @override
+  void validateConfig(Map<String, dynamic> rawConfig) {
+    validateCalls++;
+    super.validateConfig(rawConfig);
+  }
+
+  @override
+  CompiledBuiltInProxyNodes compile({
+    required Map<String, dynamic> rawConfig,
+    required ClashConfig patchConfig,
+    String globalTestUrl = '',
+    bool copyConfig = true,
+    bool validate = true,
+  }) {
+    lastCompileCopiedConfig = copyConfig;
+    lastCompileValidated = validate;
+    return super.compile(
+      rawConfig: rawConfig,
+      patchConfig: patchConfig,
+      globalTestUrl: globalTestUrl,
+      copyConfig: copyConfig,
+      validate: validate,
+    );
+  }
+}

--- a/test/product/compile/profile_split_tunneling_test.dart
+++ b/test/product/compile/profile_split_tunneling_test.dart
@@ -235,6 +235,7 @@ void main() {
         installedPackageNames: const ['com.cached.app'],
         readRemoteSource: (_) async => 'com.cached.app\n',
       );
+      _agePackageListCaches(profilesDir);
 
       final refresh = Completer<String>();
       var refreshCalls = 0;
@@ -285,6 +286,7 @@ void main() {
         installedPackageNames: const ['org.mozilla.firefox'],
         readRemoteSource: (_) async => 'org.mozilla.firefox\n',
       );
+      _agePackageListCaches(profilesDir);
 
       final invalidRefreshStarted = Completer<void>();
       final cachedResolved = await resolveAndroidProfileSplitTunneling(
@@ -351,4 +353,11 @@ void main() {
       );
     });
   });
+}
+
+void _agePackageListCaches(Directory profilesDir) {
+  final oldTimestamp = DateTime.now().subtract(const Duration(hours: 7));
+  for (final entity in profilesDir.listSync(recursive: true)) {
+    if (entity is File) entity.setLastModifiedSync(oldTimestamp);
+  }
 }

--- a/test/product/performance/runtime_optimization_contract_test.dart
+++ b/test/product/performance/runtime_optimization_contract_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('QuickJS runtime is disposed on success and failure', () async {
+    final source = await File('lib/state.dart').readAsString();
+    final method = source.substring(source.indexOf('Future<Map<String, dynamic>> handleEvaluate'));
+
+    expect(method, contains('try {'));
+    expect(method, contains('finally {'));
+    expect(method, contains('runtime.dispose();'));
+  });
+
+  test('traffic polling does not fetch groups for notification updates',
+      () async {
+    final source = await File('lib/controller.dart').readAsString();
+    final start = source.indexOf('Future<void> updateTraffic()');
+    final end = source.indexOf('void markRuntimeConfigListenerReady()', start);
+    final method = source.substring(start, end);
+
+    expect(method, isNot(contains('updateGroups')));
+    expect(method, isNot(contains('syncForegroundNotification')));
+  });
+
+  test('installed package names use native TTL and a direct channel list',
+      () async {
+    final kotlin = await File(
+      'android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt',
+    ).readAsString();
+    final dart = await File('lib/plugins/app.dart').readAsString();
+    final start = dart.indexOf('Future<List<String>> getInstalledPackageNames()');
+    final end = dart.indexOf('Future<List<String>> getChinaPackageNames()', start);
+    final method = dart.substring(start, end);
+
+    expect(kotlin, contains('installedPackageNamesLoadedAt'));
+    expect(kotlin, contains('PACKAGES_CACHE_TTL_MS'));
+    expect(method, contains('invokeMethod<List<dynamic>>'));
+    expect(method, isNot(contains('Isolate.run')));
+    expect(method, isNot(contains('json.decode')));
+  });
+
+  test('access search is debounced outside the selection state', () async {
+    final source = await File('lib/views/access.dart').readAsString();
+
+    expect(source, contains('Duration(milliseconds: 180)'));
+    expect(source, contains('buildPackageIndex(packages)'));
+    expect(source, contains('_searchDebounce?.cancel()'));
+  });
+}

--- a/test/product/performance/runtime_optimization_contract_test.dart
+++ b/test/product/performance/runtime_optimization_contract_test.dart
@@ -21,6 +21,10 @@ void main() {
 
     expect(method, isNot(contains('updateGroups')));
     expect(method, isNot(contains('syncForegroundNotification')));
+    expect(
+      source,
+      contains('syncNotification: Platform.isAndroid && globalState.isStart'),
+    );
   });
 
   test('installed package names use native TTL and a direct channel list',
@@ -35,9 +39,27 @@ void main() {
 
     expect(kotlin, contains('installedPackageNamesLoadedAt'));
     expect(kotlin, contains('PACKAGES_CACHE_TTL_MS'));
+    expect(kotlin, contains('Intent.ACTION_PACKAGE_ADDED'));
+    expect(kotlin, contains('invalidatePackageCaches()'));
+    expect(kotlin, contains('refreshInstalledAppsPermissionState()'));
     expect(method, contains('invokeMethod<List<dynamic>>'));
     expect(method, isNot(contains('Isolate.run')));
     expect(method, isNot(contains('json.decode')));
+  });
+
+  test('notification dedupe still repairs cross-process persistence', () async {
+    final source = await File(
+      'android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt',
+    ).readAsString();
+    final start = source.indexOf(
+      'override fun updateNotificationParams(params: NotificationParams)',
+    );
+    final end = source.indexOf('\n        }', start);
+    final method = source.substring(start, end);
+
+    expect(method, contains('State.notificationParamsFlow.value != params'));
+    expect(method, contains('SavedParams.saveNotificationTitle(params.title)'));
+    expect(method, isNot(contains('== params) return')));
   });
 
   test('access search is debounced outside the selection state', () async {
@@ -46,5 +68,22 @@ void main() {
     expect(source, contains('Duration(milliseconds: 180)'));
     expect(source, contains('buildPackageIndex(packages)'));
     expect(source, contains('_searchDebounce?.cancel()'));
+  });
+
+  test('first-frame metric names the post-frame callback boundary', () async {
+    final source =
+        await File('lib/product/bootstrap/app_bootstrap.dart').readAsString();
+
+    expect(source, contains('bootstrap.firstFrameCallbackMs'));
+    expect(source, isNot(contains('bootstrap.firstFrameMs=')));
+  });
+
+  test('pending runtime-plan revision includes proxy selections', () async {
+    final source = await File('lib/state.dart').readAsString();
+
+    expect(
+      source,
+      contains('json.encode(config.currentProfile?.selectedMap ?? const {})'),
+    );
   });
 }

--- a/test/product/runtime/built_in_proxy_supervisor_test.dart
+++ b/test/product/runtime/built_in_proxy_supervisor_test.dart
@@ -33,6 +33,7 @@ void main() {
       Duration Function()? monotonicNow,
       Future<void> Function(Duration)? delay,
       RuntimeHealthProbe? healthProbe,
+      Duration healthProbeTimeout = const Duration(seconds: 5),
     }) {
       final naiveLayout = NaiveProxySharedInstallLayout(
         abi: 'arm64-v8a',
@@ -57,6 +58,7 @@ void main() {
         healthProbe: healthProbe,
         monotonicNow: monotonicNow,
         delay: delay,
+        healthProbeTimeout: healthProbeTimeout,
         naiveProxy: NaiveProxyNodeController(
           binary: _FakeNaiveProxyBinaryBridge(naiveLayout, gate),
           runtime: runtime,
@@ -93,7 +95,8 @@ void main() {
       );
     });
 
-    test('prepares independent node types concurrently', () async {
+    test('reuses staged layouts while preparing independent node types',
+        () async {
       final gate = _ResolveGate(3);
       final supervisor = buildSupervisor(gate: gate);
       final plans = [_naivePlan(), _byedpiPlan(), _olcPlan()];
@@ -101,12 +104,8 @@ void main() {
       await supervisor.commitStagedRuntimePlan(plans);
       gate.enabled = true;
 
-      final starting = supervisor.start();
-      await gate.allEntered.future.timeout(const Duration(seconds: 1));
-      expect(runtime.appliedPlans, isEmpty);
-
-      gate.release.complete();
-      expect(await starting, isTrue);
+      expect(await supervisor.start(), isTrue);
+      expect(gate.entered, 0);
       expect(runtime.appliedPlans.single, hasLength(3));
     });
 
@@ -194,19 +193,15 @@ void main() {
       await _waitUntil(() => runtime.appliedPlans.length == 3);
     });
 
-    test('does not apply a background strategy after a new plan is staged',
+    test('does not persist a background strategy after a new plan is staged',
         () async {
       var elapsed = Duration.zero;
-      final gate = _ResolveGate(1);
       runtime.onBatch = () {
         if (runtime.batchCalls.length == 1) {
           elapsed += const Duration(seconds: 1);
-        } else {
-          gate.enabled = true;
         }
       };
       final supervisor = buildSupervisor(
-        gate: gate,
         byedpiStrategies: '--strategy 1\n--strategy 2',
         monotonicNow: () => elapsed,
       );
@@ -214,19 +209,21 @@ void main() {
       expect(await supervisor.stageRuntimePlan(plans), isEmpty);
       expect((await supervisor.startRuntimePlan(plans)).isSuccess, isTrue);
       runtime.batchResults.add(0);
+      runtime.applyGate = Completer<void>();
 
       await supervisor.commitStagedRuntimePlan(plans);
-      await gate.allEntered.future.timeout(const Duration(seconds: 1));
+      await _waitUntil(() => runtime.activeApplyCalls == 1);
       final staging = supervisor.stageRuntimePlan([_byedpiPlan()]);
       await Future<void>.delayed(Duration.zero);
-      gate.release.complete();
+      runtime.applyGate!.complete();
       expect(
         await staging.timeout(const Duration(seconds: 1)),
         isEmpty,
       );
       await Future<void>.delayed(Duration.zero);
 
-      expect(runtime.appliedPlans, hasLength(1));
+      expect(runtime.appliedPlans, hasLength(2));
+      expect(runtime.savedManifest, isNull);
     });
 
     test(
@@ -693,6 +690,31 @@ void main() {
         await supervisor.stop();
       },
     );
+
+    test('bounds cancellation while the current health probe is stuck',
+        () async {
+      final clock = _FakeWatchdogClock();
+      final probe = _StuckRuntimeHealthProbe();
+      final supervisor = buildSupervisor(
+        healthProbe: probe,
+        healthProbeTimeout: const Duration(milliseconds: 20),
+        monotonicNow: clock.now,
+        delay: clock.delay,
+      );
+      final plan = _olcReservePlan(failures: 1);
+      expect(await supervisor.stageRuntimePlan([plan]), isEmpty);
+      await supervisor.commitStagedRuntimePlan([plan]);
+      expect(await supervisor.start(), isTrue);
+      clock.elapse(const Duration(seconds: 1));
+      await probe.entered.future.timeout(const Duration(seconds: 1));
+
+      await supervisor.stageRuntimePlan(const []).timeout(
+          const Duration(milliseconds: 250));
+      probe.result.complete(false);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(runtime.appliedPlans.last, isEmpty);
+    });
   });
 }
 
@@ -1048,5 +1070,19 @@ class _FakeRuntimeHealthProbe implements RuntimeHealthProbe {
   Future<Map<String, String>> selectedProxies(List<String> groupNames) async {
     selectionCalls++;
     return selections;
+  }
+}
+
+class _StuckRuntimeHealthProbe extends _FakeRuntimeHealthProbe {
+  final entered = Completer<void>();
+  final result = Completer<bool>();
+
+  @override
+  Future<bool> testDelay({
+    required String proxyName,
+    required List<Uri> urls,
+  }) {
+    if (!entered.isCompleted) entered.complete();
+    return result.future;
   }
 }

--- a/test/product/runtime/built_in_proxy_supervisor_test.dart
+++ b/test/product/runtime/built_in_proxy_supervisor_test.dart
@@ -513,6 +513,34 @@ void main() {
       await supervisor.stop();
     });
 
+    test('does not sleep an awake reserve when usage probes time out',
+        () async {
+      final clock = _FakeWatchdogClock();
+      final probe = _StuckActiveConnectionsProbe()..delayResults.add(true);
+      final supervisor = buildSupervisor(
+        healthProbe: probe,
+        healthProbeTimeout: const Duration(milliseconds: 20),
+        monotonicNow: clock.now,
+        delay: clock.delay,
+      );
+      final plan = _olcReservePlan(idle: const Duration(seconds: 1));
+      expect(await supervisor.stageRuntimePlan([plan]), isEmpty);
+      await supervisor.commitStagedRuntimePlan([plan]);
+      expect(await supervisor.start(), isTrue);
+      runtime.appliedPlans.clear();
+      await supervisor.notifyProxySelected('Reserve', plan.name);
+      await _waitUntil(() => clock.pendingTimers == 1);
+
+      clock.elapse(const Duration(seconds: 1));
+      await probe.entered.future.timeout(const Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      expect(runtime.appliedPlans, hasLength(1));
+      expect(runtime.appliedPlans.single.single['type'], 'olcrtc');
+      expect(probe.selectionCalls, 0);
+      await supervisor.stop();
+    });
+
     test('VPN stop pauses auto activation but keeps always-on nodes warm',
         () async {
       final clock = _FakeWatchdogClock();
@@ -1084,5 +1112,16 @@ class _StuckRuntimeHealthProbe extends _FakeRuntimeHealthProbe {
   }) {
     if (!entered.isCompleted) entered.complete();
     return result.future;
+  }
+}
+
+class _StuckActiveConnectionsProbe extends _FakeRuntimeHealthProbe {
+  final entered = Completer<void>();
+
+  @override
+  Future<List<List<String>>> activeConnectionChains() {
+    connectionCalls++;
+    if (!entered.isCompleted) entered.complete();
+    return Completer<List<List<String>>>().future;
   }
 }

--- a/test/product/runtime/engine_manager_test.dart
+++ b/test/product/runtime/engine_manager_test.dart
@@ -494,6 +494,121 @@ void main() {
       expect(manager.activeEngineId, RuntimeId.mihomo);
     });
 
+    test('reuses the verified pending plan between init and preload', () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+      const request = EngineRuntimePlanRequest(
+        patchConfig: ClashConfig(),
+        settingsRevision: ('settings', 1),
+      );
+
+      await manager.initializeCore(
+        runtimePlanRequest: request,
+        coldStartPatchConfig: const ClashConfig(),
+        setupRuntimePlan: false,
+      );
+      await manager.setupRuntimePlan(request);
+
+      expect(buildCalls, 1);
+      expect(manager.performanceCounters.verifiedPlanReuses, 1);
+      expect(mihomoAdapter.setupRuntimePlanCalls, 1);
+    });
+
+    test('invalidates the pending plan when influencing settings change',
+        () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+
+      await manager.initializeCore(
+        runtimePlanRequest: const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 1,
+        ),
+        coldStartPatchConfig: const ClashConfig(),
+        setupRuntimePlan: false,
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 2,
+        ),
+      );
+
+      expect(buildCalls, 2);
+      expect(manager.performanceCounters.verifiedPlanReuses, 0);
+    });
+
+    test('derives and deduplicates cold-start snapshots without rebuilding',
+        () async {
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(patchConfig: ClashConfig()),
+        coldStartPatchConfig: const ClashConfig(tun: Tun(enable: false)),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await manager.persistColdStart(
+        pathConfig: const ClashConfig(tun: Tun(enable: false)),
+      );
+
+      expect(manager.performanceCounters.runtimePlanBuilds, 1);
+      expect(manager.performanceCounters.coldStartPlanDerivations, 1);
+      expect(manager.performanceCounters.coldStartSnapshotsSkipped, 1);
+      expect(mihomoAdapter.persistColdStartCalls, 1);
+    });
+
+    test('persists the latest selected proxy from the cached plan', () async {
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async =>
+            RuntimePlan.empty(
+          selectedMap: const {'Auto': 'Node A'},
+          testUrl: 'https://example.com',
+          runtime: runtimeSelection,
+        ),
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(patchConfig: ClashConfig()),
+      );
+
+      await manager.notifyProxySelected('Auto', 'Node B');
+      await manager.persistColdStart(pathConfig: const ClashConfig());
+
+      expect(
+        mihomoAdapter.lastPersistedRuntimePlan?.selectedMap,
+        {'Auto': 'Node B'},
+      );
+      expect(manager.performanceCounters.runtimePlanBuilds, 1);
+    });
+
     test('rejects runtime switch while started', () async {
       final started = await manager.start();
       expect(started, isTrue);

--- a/test/product/runtime/engine_manager_test.dart
+++ b/test/product/runtime/engine_manager_test.dart
@@ -564,6 +564,49 @@ void main() {
       expect(manager.performanceCounters.verifiedPlanReuses, 0);
     });
 
+    test('discards an older pending plan after a newer plan is applied',
+        () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+
+      await manager.initializeCore(
+        runtimePlanRequest: const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 1,
+        ),
+        coldStartPatchConfig: const ClashConfig(),
+        setupRuntimePlan: false,
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 2,
+        ),
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 1,
+        ),
+      );
+
+      expect(buildCalls, 3);
+      expect(manager.performanceCounters.verifiedPlanReuses, 0);
+    });
+
     test('derives and deduplicates cold-start snapshots without rebuilding',
         () async {
       await manager.setupRuntimePlan(

--- a/test/product/runtime/naiveproxy_node_controller_test.dart
+++ b/test/product/runtime/naiveproxy_node_controller_test.dart
@@ -115,6 +115,31 @@ void main() {
       await controller.persistColdStart(const []);
       expect(runtime.savedManifest, isNull);
     });
+
+    test('skips empty staging and reuses the stable shared layout', () async {
+      expect(
+        await controller.stageRuntimePlan(
+          currentPlans: const [],
+          nextPlans: const [],
+        ),
+        isEmpty,
+      );
+      expect(binary.resolveCalls, 0);
+
+      final plan = _plan('https://user:pass@example.com');
+      expect(
+        await controller.stageRuntimePlan(
+          currentPlans: const [],
+          nextPlans: [plan],
+        ),
+        isEmpty,
+      );
+      await controller.commitStagedRuntimePlan();
+      await controller.buildRuntimeNodes([plan]);
+      await controller.buildRuntimeNodes([plan]);
+
+      expect(binary.resolveCalls, 1);
+    });
   });
 }
 
@@ -138,9 +163,11 @@ class _FakeBinaryBridge implements NaiveProxyBinaryBridge {
   _FakeBinaryBridge(this.layout);
   final NaiveProxySharedInstallLayout layout;
   bool failResolve = false;
+  int resolveCalls = 0;
 
   @override
   Future<NaiveProxySharedInstallLayout> resolveSharedInstallLayout() async {
+    resolveCalls++;
     if (failResolve) throw const FileSystemException('cleanup failed');
     return layout;
   }

--- a/test/product/runtime/naiveproxy_node_controller_test.dart
+++ b/test/product/runtime/naiveproxy_node_controller_test.dart
@@ -140,6 +140,30 @@ void main() {
 
       expect(binary.resolveCalls, 1);
     });
+
+    test('retries shared layout resolution after a transient failure',
+        () async {
+      final plan = _plan('https://example.com');
+      binary.failResolve = true;
+
+      await expectLater(
+        controller.stageRuntimePlan(
+          currentPlans: const [],
+          nextPlans: [plan],
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      binary.failResolve = false;
+
+      expect(
+        await controller.stageRuntimePlan(
+          currentPlans: const [],
+          nextPlans: [plan],
+        ),
+        isEmpty,
+      );
+      expect(binary.resolveCalls, 2);
+    });
   });
 }
 

--- a/test/product/services/android_shell_service_test.dart
+++ b/test/product/services/android_shell_service_test.dart
@@ -78,6 +78,33 @@ void main() {
       expect(bridge.pushedTitles, ['Stable title', 'Changed title']);
     });
 
+    test('serializes concurrent notification updates in request order',
+        () async {
+      final firstGate = Completer<void>();
+      final secondGate = Completer<void>();
+      final bridge = _FakeAndroidShellPlatformBridge()
+        ..pushGates.addAll([firstGate, secondGate]);
+      final service = AndroidShellService(platform: bridge);
+
+      final first = service.pushForegroundNotificationTitle('First title');
+      final second = service.pushForegroundNotificationTitle('Second title');
+      await Future<void>.delayed(Duration.zero);
+      expect(bridge.pushedTitles, ['First title']);
+
+      firstGate.complete();
+      await first;
+      await Future<void>.delayed(Duration.zero);
+      expect(bridge.pushedTitles, ['First title', 'Second title']);
+      secondGate.complete();
+      await second;
+
+      await service.pushForegroundNotificationTitle('First title');
+      expect(
+        bridge.pushedTitles,
+        ['First title', 'Second title', 'First title'],
+      );
+    });
+
     test('delegates tile and app hooks through the platform bridge', () async {
       final bridge = _FakeAndroidShellPlatformBridge();
       final service = AndroidShellService(platform: bridge);
@@ -138,6 +165,7 @@ class _FakeAndroidShellPlatformBridge implements AndroidShellPlatformBridge {
   FutureOr<void> Function()? _onExit;
 
   final pushedTitles = <String>[];
+  final pushGates = <Completer<void>>[];
   final syncedModes = <String>[];
   final globalModeValues = <bool>[];
   final excludeFromRecentsValues = <bool>[];
@@ -203,6 +231,9 @@ class _FakeAndroidShellPlatformBridge implements AndroidShellPlatformBridge {
   @override
   Future<void> pushForegroundNotificationTitle(String title) async {
     pushedTitles.add(title);
+    if (pushGates.isNotEmpty) {
+      await pushGates.removeAt(0).future;
+    }
   }
 
   Future<void> triggerStart() async {

--- a/test/product/services/android_shell_service_test.dart
+++ b/test/product/services/android_shell_service_test.dart
@@ -67,6 +67,17 @@ void main() {
       expect(bridge.pushedTitles, ['Service Name / Node B']);
     });
 
+    test('skips unchanged foreground notification IPC', () async {
+      final bridge = _FakeAndroidShellPlatformBridge();
+      final service = AndroidShellService(platform: bridge);
+
+      await service.pushForegroundNotificationTitle('Stable title');
+      await service.pushForegroundNotificationTitle('Stable title');
+      await service.pushForegroundNotificationTitle('Changed title');
+
+      expect(bridge.pushedTitles, ['Stable title', 'Changed title']);
+    });
+
     test('delegates tile and app hooks through the platform bridge', () async {
       final bridge = _FakeAndroidShellPlatformBridge();
       final service = AndroidShellService(platform: bridge);

--- a/test/product/services/app_update_service_test.dart
+++ b/test/product/services/app_update_service_test.dart
@@ -143,6 +143,18 @@ class _FakeUpdateBridge implements AppUpdatePlatformBridge {
   }
 }
 
+class _MemoryAutomaticUpdateCheckStore implements AutomaticUpdateCheckStore {
+  DateTime? value;
+
+  @override
+  Future<DateTime?> readLastAttempt() async => value;
+
+  @override
+  Future<void> writeLastAttempt(DateTime value) async {
+    this.value = value;
+  }
+}
+
 class _FakeAppUpdateHttpClient implements AppUpdateHttpClient {
   final downloadCalls = <String>[];
   final failedDownloadUrls = <String>{};
@@ -417,7 +429,10 @@ void main() {
 
     test('passes update channel and skipped tag to automatic checks', () async {
       final bridge = _FakeUpdateBridge(updateDirectoryPath: tempDir.path);
-      final service = AppUpdateService(platform: bridge);
+      final service = AppUpdateService(
+        platform: bridge,
+        automaticCheckStore: _MemoryAutomaticUpdateCheckStore(),
+      );
 
       await service.autoCheck(
         enabled: true,
@@ -428,6 +443,37 @@ void main() {
       expect(bridge.checkCalls, 1);
       expect(bridge.includePrereleaseArgs, [true]);
       expect(bridge.skippedTagNameArgs, ['v1.2.3']);
+    });
+
+    test('does not repeat automatic network checks inside the TTL', () async {
+      final bridge = _FakeUpdateBridge(updateDirectoryPath: tempDir.path);
+      final store = _MemoryAutomaticUpdateCheckStore();
+      var now = DateTime(2026, 7, 21, 10);
+      final service = AppUpdateService(
+        platform: bridge,
+        automaticCheckStore: store,
+        now: () => now,
+      );
+
+      await service.autoCheck(
+        enabled: true,
+        includePrerelease: false,
+        skippedTagName: '',
+      );
+      now = now.add(const Duration(hours: 1));
+      await service.autoCheck(
+        enabled: true,
+        includePrerelease: false,
+        skippedTagName: '',
+      );
+      now = now.add(const Duration(hours: 12));
+      await service.autoCheck(
+        enabled: true,
+        includePrerelease: false,
+        skippedTagName: '',
+      );
+
+      expect(bridge.checkCalls, 2);
     });
 
     test('downloads verifies and installs a compatible Android APK', () async {


### PR DESCRIPTION
## Проблема

Аудит выявил повторные дорогие проходы на cold start, preview и apply: чтение и разбор YAML, выполнение QuickJS, компиляцию профиля и пересборку runtime plan. Параллельно foreground notification регулярно инициировала неизменившиеся IPC и fsync, Android inventory повторно сканировал пакеты, а часть необязательной работы задерживала первый кадр. Отмена OlcRTC health probe могла зависнуть на текущем запросе.

## Решение

- Добавлен revision-aware кэш загрузки профиля с дедупликацией concurrent запросов. Ревизия учитывает файл, override, скрипт и влияющие runtime-настройки; выбранный proxy не инвалидирует YAML и script evaluation.
- RawProfile сделан неизменяемым, а compiler transaction выполняет одну глубокую копию и одну валидацию.
- Проверенный runtime plan переиспользуется для cold-start persistence и смены proxy. Фоновые записи объединяются по latest-wins, неизменившийся snapshot пропускается.
- Убрано периодическое чтение полных proxy groups ради notification. Заголовок foreground notification проходит Dart, IPC и native persistence только при фактическом изменении; реальная смена proxy обновляет его сразу.
- Inventory установленных пакетов кэшируется на Android на 30 секунд с явной инвалидацией после выдачи vendor permission; MethodChannel возвращает список напрямую без JSON/isolate.
- Пустые built-in controllers не stagingуются, стабильный shared layout кэшируется. Последовательный staging сохранён ради доказуемого rollback.
- OlcRTC watchdog ограничивает каждый health probe таймаутом и защищён generation check.
- Core preload запускается параллельно после обязательной Android tile-инициализации, dynamic color и часть config preload вынесены из пути первого кадра. Автоматическая проверка обновлений ограничена persistent-интервалом 12 часов, ручная проверка не менялась.
- Access Control использует предвычисленные search/sort keys, Set для точных package selectors и debounce поиска без потери текущего выбора.
- Добавлены точечные счётчики и регрессионные тесты, проверяющие дедупликацию проходов, IPC, persistence и platform scans.

## Безопасность и риски

Security policy, readiness, rollback, cold-start floor, TLS/public-IP проверки и self-bypass не ослаблены. Кэши профиля инвалидируются по mtime, размеру, override, скрипту и runtime-настройкам; Android package inventory может быть старше фактического состояния максимум на 30 секунд. Dynamic color применяется после первого кадра, поэтому на старте кратко используется fallback-тема. Автоматическая проверка обновлений может быть отложена до 12 часов, ручная остаётся немедленной.

## Проверки

- dart tool/check_product_boundaries.dart — пройдено
- flutter test test/product — 314 тестов пройдено
- dart tool/check_base_drift.dart — пройдено, 106 из 106 base-изменений зарегистрированы
- flutter analyze — выполнено; compile errors отсутствуют, строгий запуск фиксирует существующий проектный backlog из 589 warning/info
- flutter analyze --no-fatal-infos --no-fatal-warnings — пройдено
- Android :service:testDebugUnitTest — пройдено
- Android :app:compileDebugKotlin — пройдено
- flutter build apk --debug --target-platform android-arm64 — пройдено, debug APK собран
- git diff --check и проверка случайных секретов — пройдены

## Намеренно не изменено

applicationId com.makriq.flclash сохранён. Foreground budget ByeDPI не сокращался: воспроизводимых данных для безопасного изменения нет. Macrobenchmark и Baseline Profile не добавлялись, поскольку в текущем scope нет стабильного device benchmark harness; измеримый follow-up — Android benchmark cold start и profile apply на фиксированном устройстве с добавленными startup-метками и runtime-счётчиками.