### PR TITLE
Безопасно оптимизировать работу клиента

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -109,9 +109,6 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("com.android.tools.smali:smali-dexlib2:3.0.9") {
-        exclude(group = "com.google.guava", module = "guava")
-    }
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation(platform("com.google.firebase:firebase-bom:34.15.0"))
     implementation("com.google.firebase:firebase-crashlytics-ndk")

--- a/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clashx/plugins/AppPlugin.kt
@@ -4,10 +4,12 @@ import android.Manifest
 import android.app.Activity
 import android.app.ActivityManager
 import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
 import android.content.ClipData
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
-import android.content.pm.ComponentInfo
 import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.Build
@@ -20,7 +22,6 @@ import androidx.core.content.FileProvider
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
-import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile
 import com.follow.clashx.FlClashApplication
 import com.follow.clashx.R
 import com.follow.clashx.extensions.getActionIntent
@@ -45,7 +46,6 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Collections
-import java.util.zip.ZipFile
 
 // How long the installed-packages snapshot stays fresh. TTL, not load-once: a
 // process-lifetime cache never showed apps (un)installed while FlClashX ran.
@@ -76,61 +76,15 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
     )
 
     private val packages = mutableListOf<Package>()
+    private var installedPackageSnapshot: List<android.content.pm.PackageInfo> = emptyList()
     private var packagesLoadedAt = 0L
+    private var installedAppsPermissionGranted: Boolean? = null
+    private var packageChangesReceiverRegistered = false
 
-    private val skipPrefixList = listOf(
-        "com.google",
-        "com.android.chrome",
-        "com.android.vending",
-        "com.microsoft",
-        "com.apple",
-        "com.zhiliaoapp.musically", // Banned by China
-    )
-
-    private val chinaAppPrefixList = listOf(
-        "com.tencent",
-        "com.alibaba",
-        "com.umeng",
-        "com.qihoo",
-        "com.ali",
-        "com.alipay",
-        "com.amap",
-        "com.sina",
-        "com.weibo",
-        "com.vivo",
-        "com.xiaomi",
-        "com.huawei",
-        "com.taobao",
-        "com.secneo",
-        "s.h.e.l.l",
-        "com.stub",
-        "com.kiwisec",
-        "com.secshell",
-        "com.wrapper",
-        "cn.securitystack",
-        "com.mogosec",
-        "com.secoen",
-        "com.netease",
-        "com.mx",
-        "com.qq.e",
-        "com.baidu",
-        "com.bytedance",
-        "com.bugly",
-        "com.miui",
-        "com.oppo",
-        "com.coloros",
-        "com.iqoo",
-        "com.meizu",
-        "com.gionee",
-        "cn.nubia",
-        "com.oplus",
-        "andes.oplus",
-        "com.unionpay",
-        "cn.wps"
-    )
-
-    private val chinaAppRegex by lazy {
-        ("(" + chinaAppPrefixList.joinToString("|").replace(".", "\\.") + ").*").toRegex()
+    private val packageChangesReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            invalidatePackageCaches()
+        }
     }
 
     val VPN_PERMISSION_REQUEST_CODE = 1001
@@ -149,6 +103,7 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "app")
         channel.setMethodCallHandler(this)
+        registerPackageChangesReceiver()
     }
 
     private fun initShortcuts(toggle: String, start: String, stop: String) {
@@ -174,7 +129,65 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        unregisterPackageChangesReceiver()
         scope.cancel()
+    }
+
+    private fun registerPackageChangesReceiver() {
+        if (packageChangesReceiverRegistered) return
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_PACKAGE_ADDED)
+            addAction(Intent.ACTION_PACKAGE_REMOVED)
+            addAction(Intent.ACTION_PACKAGE_CHANGED)
+            addAction(Intent.ACTION_PACKAGE_REPLACED)
+            addDataScheme("package")
+        }
+        packageChangesReceiverRegistered = runCatching {
+            ContextCompat.registerReceiver(
+                FlClashApplication.getAppContext(),
+                packageChangesReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        }.isSuccess
+    }
+
+    private fun unregisterPackageChangesReceiver() {
+        if (!packageChangesReceiverRegistered) return
+        runCatching {
+            FlClashApplication.getAppContext().unregisterReceiver(packageChangesReceiver)
+        }
+        packageChangesReceiverRegistered = false
+    }
+
+    @Synchronized
+    private fun invalidatePackageCaches() {
+        installedPackageSnapshot = emptyList()
+        packages.clear()
+        packagesLoadedAt = 0L
+        iconMap.clear()
+    }
+
+    private fun hasInstalledAppsPermission(): Boolean {
+        val context = FlClashApplication.getAppContext()
+        val defined = try {
+            context.packageManager?.getPermissionInfo(GET_INSTALLED_APPS_PERMISSION, 0) != null
+        } catch (_: Exception) {
+            false
+        }
+        return !defined || ContextCompat.checkSelfPermission(
+            context,
+            GET_INSTALLED_APPS_PERMISSION,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @Synchronized
+    private fun refreshInstalledAppsPermissionState() {
+        val granted = hasInstalledAppsPermission()
+        if (installedAppsPermissionGranted != null && installedAppsPermissionGranted != granted) {
+            invalidatePackageCaches()
+        }
+        installedAppsPermissionGranted = granted
     }
 
     private fun tip(message: String?) {
@@ -218,13 +231,6 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
             "getInstalledPackageNames" -> {
                 scope.launch(Dispatchers.IO) {
                     val names = getInstalledPackageNames()
-                    result.successOnMain(names)
-                }
-            }
-
-            "getChinaPackageNames" -> {
-                scope.launch(Dispatchers.IO) {
-                    val names = getChinaPackageNames()
                     result.successOnMain(names)
                 }
             }
@@ -489,18 +495,31 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
     }
 
     @Synchronized
-    private fun getPackages(): List<Package> {
+    private fun getInstalledPackageSnapshot(): List<android.content.pm.PackageInfo> {
+        refreshInstalledAppsPermissionState()
         val packageManager = FlClashApplication.getAppContext().packageManager
         val now = android.os.SystemClock.elapsedRealtime()
-        if (packages.isNotEmpty() && now - packagesLoadedAt < PACKAGES_CACHE_TTL_MS) {
-            return packages.toList()
+        if (packagesLoadedAt != 0L && now - packagesLoadedAt < PACKAGES_CACHE_TTL_MS) {
+            return installedPackageSnapshot
         }
+        installedPackageSnapshot = packageManager
+            ?.getInstalledPackages(PackageManager.GET_META_DATA or PackageManager.GET_PERMISSIONS)
+            ?.toList()
+            ?: emptyList()
         packages.clear()
-        packageManager?.getInstalledPackages(PackageManager.GET_META_DATA or PackageManager.GET_PERMISSIONS)
-            ?.filter {
-                it.packageName != FlClashApplication.getAppContext().packageName || it.packageName == "android"
+        packagesLoadedAt = now
+        return installedPackageSnapshot
+    }
 
-            }?.map {
+    @Synchronized
+    private fun getPackages(): List<Package> {
+        val packageManager = FlClashApplication.getAppContext().packageManager
+        val snapshot = getInstalledPackageSnapshot()
+        if (packages.isEmpty()) {
+            snapshot.filter {
+                it.packageName != FlClashApplication.getAppContext().packageName ||
+                    it.packageName == "android"
+            }.map {
                 Package(
                     packageName = it.packageName,
                     label = it.applicationInfo?.loadLabel(packageManager)?.toString() ?: it.packageName,
@@ -508,10 +527,8 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
                     lastUpdateTime = it.lastUpdateTime,
                     internet = it.requestedPermissions?.contains(Manifest.permission.INTERNET) == true
                 )
-            }?.let { packages.addAll(it) }
-        packagesLoadedAt = now
-        // Snapshot: callers serialize/filter outside this lock while a later refresh
-        // may clear() the backing list mid-iteration.
+            }.let { packages.addAll(it) }
+        }
         return packages.toList()
     }
 
@@ -521,23 +538,12 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         }
     }
 
-    private suspend fun getInstalledPackageNames(): String {
+    private suspend fun getInstalledPackageNames(): List<String> {
         return withContext(Dispatchers.IO) {
-            val packageManager = FlClashApplication.getAppContext().packageManager
-            val packageNames = packageManager
-                ?.getInstalledPackages(0)
-                ?.map { it.packageName }
-                ?.filter { it.isNotBlank() }
-                ?: emptyList()
-            Gson().toJson(packageNames)
-        }
-    }
-
-    private suspend fun getChinaPackageNames(): String {
-        return withContext(Dispatchers.IO) {
-            val packages: List<String> =
-                getPackages().map { it.packageName }.filter { isChinaPackage(it) }
-            Gson().toJson(packages)
+            getInstalledPackageSnapshot()
+                .map { it.packageName }
+                .filter { it.isNotBlank() }
+                .distinct()
         }
     }
 
@@ -590,77 +596,6 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
                 }
             }
         }
-    }
-
-    private fun isChinaPackage(packageName: String): Boolean {
-        val packageManager = FlClashApplication.getAppContext().packageManager ?: return false
-        skipPrefixList.forEach {
-            if (packageName == it || packageName.startsWith("$it.")) return false
-        }
-        val packageManagerFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            PackageManager.MATCH_UNINSTALLED_PACKAGES or PackageManager.GET_ACTIVITIES or PackageManager.GET_SERVICES or PackageManager.GET_RECEIVERS or PackageManager.GET_PROVIDERS
-        } else {
-            @Suppress("DEPRECATION")
-            PackageManager.GET_UNINSTALLED_PACKAGES or PackageManager.GET_ACTIVITIES or PackageManager.GET_SERVICES or PackageManager.GET_RECEIVERS or PackageManager.GET_PROVIDERS
-        }
-        if (packageName.matches(chinaAppRegex)) {
-            return true
-        }
-        try {
-            val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                packageManager.getPackageInfo(
-                    packageName,
-                    PackageManager.PackageInfoFlags.of(packageManagerFlags.toLong())
-                )
-            } else {
-                packageManager.getPackageInfo(
-                    packageName, packageManagerFlags
-                )
-            }
-            mutableListOf<ComponentInfo>().apply {
-                packageInfo.services?.let { addAll(it) }
-                packageInfo.activities?.let { addAll(it) }
-                packageInfo.receivers?.let { addAll(it) }
-                packageInfo.providers?.let { addAll(it) }
-            }.forEach {
-                if (it.name.matches(chinaAppRegex)) return true
-            }
-            packageInfo.applicationInfo?.publicSourceDir?.let {
-                ZipFile(File(it)).use {
-                    for (packageEntry in it.entries()) {
-                        if (packageEntry.name.startsWith("firebase-")) return false
-                    }
-                    for (packageEntry in it.entries()) {
-                        if (!(packageEntry.name.startsWith("classes") && packageEntry.name.endsWith(
-                                ".dex"
-                            ))
-                        ) {
-                            continue
-                        }
-                        if (packageEntry.size > 15000000) {
-                            return true
-                        }
-                        val input = it.getInputStream(packageEntry).buffered()
-                        val dexFile = try {
-                            DexBackedDexFile.fromInputStream(null, input)
-                        } catch (e: Exception) {
-                            return false
-                        } finally {
-                            input.close()
-                        }
-                        for (clazz in dexFile.classes) {
-                            val clazzName =
-                                clazz.type.substring(1, clazz.type.length - 1).replace("/", ".")
-                                    .replace("$", ".")
-                            if (clazzName.matches(chinaAppRegex)) return true
-                        }
-                    }
-                }
-            }
-        } catch (_: Exception) {
-            return false
-        }
-        return false
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
@@ -723,8 +658,8 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
                 // A pre-grant load may have cached the ROM's stripped-down list
                 // moments ago; drop it so the pending callbacks fetch the real one.
                 synchronized(this) {
-                    packages.clear()
-                    packagesLoadedAt = 0L
+                    invalidatePackageCaches()
+                    installedAppsPermissionGranted = true
                 }
             }
             val pending = installedAppsCallbacks.toList()

--- a/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
+++ b/android/common/src/main/kotlin/com/follow/clashx/common/SavedParams.kt
@@ -154,6 +154,13 @@ object SavedParams {
 
     fun saveNotificationTitle(title: String) {
         runCatching {
+            val currentTitle = runCatching {
+                if (notifTitleFile.exists()) notifTitleFile.readText() else null
+            }.getOrNull()
+            if (currentTitle == title) {
+                legacyNotifTitleFile.delete()
+                return@runCatching
+            }
             writeAtomic(notifTitleFile, title)
             legacyNotifTitleFile.delete()
         }

--- a/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
+++ b/android/service/src/main/kotlin/com/follow/clashx/service/RemoteService.kt
@@ -126,7 +126,9 @@ class RemoteService : Service() {
         }
 
         override fun updateNotificationParams(params: NotificationParams) {
-            State.notificationParamsFlow.value = params
+            if (State.notificationParamsFlow.value != params) {
+                State.notificationParamsFlow.value = params
+            }
             com.follow.clashx.common.SavedParams.saveNotificationTitle(params.title)
         }
 

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -262,10 +262,18 @@ class AppController {
   }
 
   Future<void> updateTraffic() async {
-    final traffic = await clashCore.getTraffic();
+    final trafficResults = await Future.wait([
+      clashCore.getTraffic(),
+      clashCore.getTotalTraffic(),
+    ]);
+    final traffic = trafficResults[0];
+    final totalTraffic = trafficResults[1];
     _ref.read(trafficsProvider.notifier).addTraffic(traffic);
-    _ref.read(totalTrafficProvider.notifier).value =
-        await clashCore.getTotalTraffic();
+    final currentTotalTraffic = _ref.read(totalTrafficProvider);
+    if (currentTotalTraffic.up.value != totalTraffic.up.value ||
+        currentTotalTraffic.down.value != totalTraffic.down.value) {
+      _ref.read(totalTrafficProvider.notifier).value = totalTraffic;
+    }
     await _syncRuntimeGroupsForNotification();
   }
 
@@ -646,6 +654,10 @@ class AppController {
   }) =>
       EngineRuntimePlanRequest(
         patchConfig: patchConfig,
+        settingsRevision: (
+          globalState.runtimePlanSettingsRevision,
+          _ref.read(realTunEnableProvider),
+        ),
         refreshProfile: refreshProfile
             ? () async {
                 await _ref.read(currentProfileProvider)?.checkAndUpdate();
@@ -897,9 +909,11 @@ class AppController {
       );
 
       if (newGroups.isNotEmpty) {
-        _ref.read(groupsProvider.notifier).value = newGroups;
-        _ref.read(versionProvider.notifier).value =
-            _ref.read(versionProvider) + 1;
+        if (!listEquals(_ref.read(groupsProvider), newGroups)) {
+          _ref.read(groupsProvider.notifier).value = newGroups;
+          _ref.read(versionProvider.notifier).value =
+              _ref.read(versionProvider) + 1;
+        }
         if (syncNotification) {
           await syncAndroidForegroundNotification();
         }

--- a/lib/plugins/app.dart
+++ b/lib/plugins/app.dart
@@ -52,23 +52,10 @@ class App {
   }
 
   Future<List<String>> getInstalledPackageNames() async {
-    final packageNamesString =
-        await methodChannel.invokeMethod<String>("getInstalledPackageNames");
-    return Isolate.run<List<String>>(() {
-      final List<dynamic> packageNamesRaw =
-          packageNamesString != null ? json.decode(packageNamesString) : [];
-      return packageNamesRaw.map((e) => e.toString()).toList();
-    });
-  }
-
-  Future<List<String>> getChinaPackageNames() async {
-    final packageNamesString =
-        await methodChannel.invokeMethod<String>("getChinaPackageNames");
-    return Isolate.run<List<String>>(() {
-      final List<dynamic> packageNamesRaw =
-          packageNamesString != null ? json.decode(packageNamesString) : [];
-      return packageNamesRaw.map((e) => e.toString()).toList();
-    });
+    final packageNames = await methodChannel.invokeListMethod<String>(
+      "getInstalledPackageNames",
+    );
+    return packageNames ?? const [];
   }
 
   Future<bool> openFile(String path) async => await methodChannel.invokeMethod<bool>("openFile", {

--- a/lib/product/android/android_update_bridge.dart
+++ b/lib/product/android/android_update_bridge.dart
@@ -125,7 +125,7 @@ abstract interface class AppUpdatePlatformBridge {
 
   Future<String?> readRemoteText(String url);
 
-  Future<void> downloadReleaseAsset(
+  Future<String> downloadReleaseAsset(
     ReleaseAsset asset,
     String targetPath, {
     required String expectedSha256,
@@ -341,7 +341,7 @@ class AndroidUpdateBridge implements AppUpdatePlatformBridge {
   Future<String?> readRemoteText(String url) => httpClient.readText(url);
 
   @override
-  Future<void> downloadReleaseAsset(
+  Future<String> downloadReleaseAsset(
     ReleaseAsset asset,
     String targetPath, {
     required String expectedSha256,
@@ -363,7 +363,7 @@ class AndroidUpdateBridge implements AppUpdatePlatformBridge {
         if (actualSha256 != expectedSha256) {
           throw StateError('SHA256 verification failed for mirror `$url`.');
         }
-        return;
+        return actualSha256;
       } catch (error) {
         lastError = error;
         commonPrint.log('Failed to download app update mirror `$url`: $error');

--- a/lib/product/compile/built_in_proxy_compiler.dart
+++ b/lib/product/compile/built_in_proxy_compiler.dart
@@ -69,11 +69,15 @@ class BuiltInProxyCompiler {
     required Map<String, dynamic> rawConfig,
     required ClashConfig patchConfig,
     String globalTestUrl = '',
+    bool copyConfig = true,
+    bool validate = true,
   }) {
-    final normalizedConfig = copyConfigTree(rawConfig);
+    final normalizedConfig = copyConfig ? copyConfigTree(rawConfig) : rawConfig;
     final proxyEntries = normalizedConfig['proxies'];
     if (proxyEntries is! List) {
-      validateConfig(normalizedConfig);
+      if (validate) {
+        validateConfig(normalizedConfig);
+      }
       normalizedConfig.remove('x-flclashm-runtime');
       return CompiledBuiltInProxyNodes(
         config: normalizedConfig,
@@ -81,7 +85,9 @@ class BuiltInProxyCompiler {
       );
     }
 
-    validateConfig(normalizedConfig);
+    if (validate) {
+      validateConfig(normalizedConfig);
+    }
     normalizedConfig.remove('x-flclashm-runtime');
 
     final reservedPorts = _collectReservedPorts(

--- a/lib/product/compile/config_tree.dart
+++ b/lib/product/compile/config_tree.dart
@@ -3,6 +3,23 @@ Map<String, dynamic> copyConfigTree(Map<String, dynamic> source) => {
         entry.key: _copyConfigValue(entry.value),
     };
 
+Map<String, dynamic> freezeConfigTree(Map<String, dynamic> source) =>
+    Map<String, dynamic>.unmodifiable({
+      for (final entry in source.entries)
+        entry.key: _freezeConfigValue(entry.value),
+    });
+
+dynamic _freezeConfigValue(dynamic value) => switch (value) {
+      final Map<dynamic, dynamic> map => Map<String, dynamic>.unmodifiable({
+          for (final entry in map.entries)
+            entry.key.toString(): _freezeConfigValue(entry.value),
+        }),
+      final List<dynamic> list => List<dynamic>.unmodifiable(
+          list.map(_freezeConfigValue),
+        ),
+      _ => value,
+    };
+
 dynamic _copyConfigValue(dynamic value) => switch (value) {
       final Map<dynamic, dynamic> map => <String, dynamic>{
           for (final entry in map.entries)

--- a/lib/product/compile/loaded_profile_repository.dart
+++ b/lib/product/compile/loaded_profile_repository.dart
@@ -1,0 +1,47 @@
+import 'raw_profile.dart';
+
+typedef LoadRawProfileRevision = Future<RawProfile> Function();
+
+/// Shares YAML parsing and script evaluation only for an exact profile
+/// revision. A superseded in-flight load can finish for its caller, but can no
+/// longer replace the current cache entry.
+class LoadedProfileRepository {
+  RawProfile? _cached;
+  RawProfileRevision? _loadingRevision;
+  Future<RawProfile>? _loading;
+
+  Future<RawProfile> load(
+    RawProfileRevision revision,
+    LoadRawProfileRevision loader,
+  ) async {
+    final cached = _cached;
+    if (cached?.revision == revision) {
+      return cached!;
+    }
+    if (_loadingRevision == revision && _loading != null) {
+      return _loading!;
+    }
+
+    final task = loader();
+    _loadingRevision = revision;
+    _loading = task;
+    try {
+      final loaded = await task;
+      if (identical(_loading, task) && _loadingRevision == revision) {
+        _cached = loaded;
+      }
+      return loaded;
+    } finally {
+      if (identical(_loading, task)) {
+        _loading = null;
+        _loadingRevision = null;
+      }
+    }
+  }
+
+  void clear() {
+    _cached = null;
+    _loading = null;
+    _loadingRevision = null;
+  }
+}

--- a/lib/product/compile/product_compile.dart
+++ b/lib/product/compile/product_compile.dart
@@ -1,4 +1,5 @@
 export 'built_in_proxy_compiler.dart';
+export 'loaded_profile_repository.dart';
 export 'olcrtc_config_validator.dart';
 export 'product_profile_pipeline.dart';
 export 'product_profile_validator.dart';

--- a/lib/product/compile/profile_compiler.dart
+++ b/lib/product/compile/profile_compiler.dart
@@ -134,6 +134,8 @@ class ProfileCompiler {
       rawConfig: resolvedProfileSplitTunneling.config,
       patchConfig: patchConfig,
       globalTestUrl: testUrl,
+      copyConfig: false,
+      validate: false,
     );
     rawConfig = compiledBuiltInProxyNodes.config;
 

--- a/lib/product/compile/profile_split_tunneling.dart
+++ b/lib/product/compile/profile_split_tunneling.dart
@@ -124,6 +124,22 @@ Future<ResolvedProfileSplitTunneling> resolveAndroidProfileSplitTunneling({
   }
 
   final normalizedTun = Map<String, dynamic>.from(tun);
+  final sourceSelectors = await Future.wait([
+    _readPackageLists(
+      mergedIncludeSources,
+      profilesPath: profilesPath,
+      profileId: profileId,
+      fieldName: 'tun.include-package-file',
+      readRemoteSource: readRemoteSource,
+    ),
+    _readPackageLists(
+      mergedExcludeSources,
+      profilesPath: profilesPath,
+      profileId: profileId,
+      fieldName: 'tun.exclude-package-file',
+      readRemoteSource: readRemoteSource,
+    ),
+  ]);
   final includeSelectorEntries = <_PackageSelectorEntry>[
     ...inlineIncludeSelectors.map(
       (selector) => _PackageSelectorEntry(
@@ -131,14 +147,7 @@ Future<ResolvedProfileSplitTunneling> resolveAndroidProfileSplitTunneling({
         preserveExactSelectorWithoutInstalledPackages: true,
       ),
     ),
-    ...(await _readPackageLists(
-      mergedIncludeSources,
-      profilesPath: profilesPath,
-      profileId: profileId,
-      fieldName: 'tun.include-package-file',
-      readRemoteSource: readRemoteSource,
-    ))
-        .map(
+    ...sourceSelectors[0].map(
       (selector) => _PackageSelectorEntry(
         value: selector,
         preserveExactSelectorWithoutInstalledPackages: false,
@@ -152,14 +161,7 @@ Future<ResolvedProfileSplitTunneling> resolveAndroidProfileSplitTunneling({
         preserveExactSelectorWithoutInstalledPackages: true,
       ),
     ),
-    ...(await _readPackageLists(
-      mergedExcludeSources,
-      profilesPath: profilesPath,
-      profileId: profileId,
-      fieldName: 'tun.exclude-package-file',
-      readRemoteSource: readRemoteSource,
-    ))
-        .map(
+    ...sourceSelectors[1].map(
       (selector) => _PackageSelectorEntry(
         value: selector,
         preserveExactSelectorWithoutInstalledPackages: false,
@@ -395,7 +397,7 @@ Future<List<String>> _readPackageLists(
   ReadProfileSplitTunnelingRemoteSource? readRemoteSource,
 }) async {
   final packages = <String>[];
-  for (final source in sources) {
+  Future<List<String>> readSource(_PackageListSource source) async {
     final sourceFieldName =
         source.url != null ? fieldName.replaceAll('-file', '-url') : fieldName;
     final readResult = source.url != null
@@ -423,9 +425,18 @@ Future<List<String>> _readPackageLists(
     if (!readResult.fromCache && readResult.cachePath != null) {
       await _writePackageListCache(readResult.cachePath!, readResult.content);
     }
-    packages.addAll(
-      selectors,
+    return selectors;
+  }
+
+  const maxConcurrentReads = 4;
+  for (var offset = 0; offset < sources.length; offset += maxConcurrentReads) {
+    final proposedEnd = offset + maxConcurrentReads;
+    final end =
+        proposedEnd < sources.length ? proposedEnd : sources.length;
+    final results = await Future.wait(
+      sources.sublist(offset, end).map(readSource),
     );
+    results.forEach(packages.addAll);
   }
   return packages;
 }

--- a/lib/product/compile/raw_profile.dart
+++ b/lib/product/compile/raw_profile.dart
@@ -2,6 +2,51 @@ import 'package:flclashx/enum/enum.dart';
 import 'package:flclashx/models/models.dart';
 import 'package:flutter/foundation.dart';
 
+import 'config_tree.dart';
+
+@immutable
+class RawProfileRevision {
+  const RawProfileRevision({
+    required this.profileId,
+    required this.overrideData,
+    required this.lastModifiedMicros,
+    required this.changedMicros,
+    required this.fileSize,
+    this.scriptId,
+    this.scriptContent,
+  });
+
+  final String profileId;
+  final OverrideData overrideData;
+  final int lastModifiedMicros;
+  final int changedMicros;
+  final int fileSize;
+  final String? scriptId;
+  final String? scriptContent;
+
+  @override
+  bool operator ==(Object other) =>
+      other is RawProfileRevision &&
+      other.profileId == profileId &&
+      other.overrideData == overrideData &&
+      other.lastModifiedMicros == lastModifiedMicros &&
+      other.changedMicros == changedMicros &&
+      other.fileSize == fileSize &&
+      other.scriptId == scriptId &&
+      other.scriptContent == scriptContent;
+
+  @override
+  int get hashCode => Object.hash(
+        profileId,
+        overrideData,
+        lastModifiedMicros,
+        changedMicros,
+        fileSize,
+        scriptId,
+        scriptContent,
+      );
+}
+
 @immutable
 class RawProfile {
   const RawProfile({
@@ -9,15 +54,17 @@ class RawProfile {
     required this.config,
     required this.groupDescriptions,
     required this.providerHints,
+    this.revision,
   });
 
   factory RawProfile.fromConfig({
     required Profile profile,
     required Map<String, dynamic> config,
+    RawProfileRevision? revision,
   }) =>
       RawProfile(
         profile: profile,
-        config: config,
+        config: freezeConfigTree(config),
         groupDescriptions: _parseGroupDescriptions(config["proxy-groups"]),
         providerHints: ProviderAdvisoryHints(
           network: ProviderNetworkHints(
@@ -36,12 +83,14 @@ class RawProfile {
           externalController:
               _trimmedString(config["external-controller"]) ?? "",
         ),
+        revision: revision,
       );
 
   final Profile profile;
   final Map<String, dynamic> config;
   final Map<String, String> groupDescriptions;
   final ProviderAdvisoryHints providerHints;
+  final RawProfileRevision? revision;
 
   static Map<String, String> _parseGroupDescriptions(Object? groups) {
     final descriptions = <String, String>{};

--- a/lib/product/runtime/engine_manager.dart
+++ b/lib/product/runtime/engine_manager.dart
@@ -58,12 +58,14 @@ class ResolvedTunAccess {
 class EngineRuntimePlanRequest {
   const EngineRuntimePlanRequest({
     required this.patchConfig,
+    this.settingsRevision,
     this.refreshProfile,
     this.resolveTunAccess,
     this.onPatchConfigResolved,
   });
 
   final ClashConfig patchConfig;
+  final Object? settingsRevision;
   final FutureOr<void> Function()? refreshProfile;
   final ResolveTunAccessCallback? resolveTunAccess;
   final ValueChanged<ClashConfig>? onPatchConfigResolved;
@@ -87,12 +89,16 @@ class _CompiledRuntimePlan {
     required this.resolvedRuntime,
     required this.rawProfile,
     required this.securedProfile,
+    required this.requestedPatchConfig,
+    required this.settingsRevision,
   });
 
   final AppliedRuntimePlan appliedRuntimePlan;
   final ResolvedRuntimeSelection resolvedRuntime;
   final RawProfile? rawProfile;
   final SecuredProfilePatch securedProfile;
+  final ClashConfig requestedPatchConfig;
+  final Object? settingsRevision;
 }
 
 class EngineManager {
@@ -133,6 +139,7 @@ class EngineManager {
   RuntimeUpdateTasks _updateTasks = const [];
   DateTime? _startTime;
   _CompiledRuntimePlan? _lastCompiledRuntimePlan;
+  _CompiledRuntimePlan? _pendingCompiledRuntimePlan;
   Future<void> _coldStartPersistChain = Future<void>.value();
 
   EngineAdapter get _adapter => _activeRuntime.engine.adapter;
@@ -204,8 +211,10 @@ class EngineManager {
     return true;
   }
 
-  Future<void> notifyProxySelected(String groupName, String proxyName) =>
-      _adapter.notifyProxySelected(groupName, proxyName);
+  Future<void> notifyProxySelected(String groupName, String proxyName) async {
+    _syncCachedRuntimePlanWithProxySelection(groupName, proxyName);
+    await _adapter.notifyProxySelected(groupName, proxyName);
+  }
 
   Future<void> stop() async {
     Object? error;
@@ -304,6 +313,7 @@ class EngineManager {
     }
 
     if (!setupRuntimePlan) {
+      _pendingCompiledRuntimePlan = compiledRuntimePlan;
       return true;
     }
 
@@ -431,6 +441,14 @@ class EngineManager {
     await request.refreshProfile?.call();
 
     final rawProfile = await _loadCurrentRawProfile();
+    final pending = _pendingCompiledRuntimePlan;
+    if (pending != null &&
+        pending.requestedPatchConfig == request.patchConfig &&
+        pending.settingsRevision == request.settingsRevision &&
+        _sameRawProfileRevision(pending.rawProfile, rawProfile)) {
+      return pending;
+    }
+
     final compiledProfile = _compileProfilePatch(
       rawProfile: rawProfile,
       patchConfig: request.patchConfig,
@@ -466,7 +484,21 @@ class EngineManager {
       resolvedRuntime: resolvedRuntime,
       rawProfile: rawProfile,
       securedProfile: securedProfile,
+      requestedPatchConfig: request.patchConfig,
+      settingsRevision: request.settingsRevision,
     );
+  }
+
+  bool _sameRawProfileRevision(RawProfile? left, RawProfile? right) {
+    if (left == null || right == null) {
+      return left == right;
+    }
+    final leftRevision = left.revision;
+    final rightRevision = right.revision;
+    if (leftRevision != null || rightRevision != null) {
+      return leftRevision == rightRevision;
+    }
+    return identical(left, right);
   }
 
   Future<ClashConfig?> _resolvePatchConfig(
@@ -519,6 +551,7 @@ class EngineManager {
 
     _activeRuntime = compiledRuntimePlan.resolvedRuntime;
     _lastCompiledRuntimePlan = compiledRuntimePlan;
+    _pendingCompiledRuntimePlan = null;
     _applyRuntimePlan(compiledRuntimePlan.appliedRuntimePlan.runtimePlan);
 
     if (coldStartPatchConfig != null) {
@@ -563,27 +596,11 @@ class EngineManager {
     _CompiledRuntimePlan compiledRuntimePlan, {
     required ClashConfig coldStartPatchConfig,
   }) async {
-    final resolvedColdStartPatchConfig = _resolveColdStartPatchConfig(
-      runtimePatchConfig: compiledRuntimePlan.appliedRuntimePlan.patchConfig,
-      coldStartPatchConfig: coldStartPatchConfig,
+    final coldStartRuntimePlan = _deriveColdStartRuntimePlan(
+      compiledRuntimePlan.appliedRuntimePlan.runtimePlan,
+      coldStartPatchConfig,
     );
-    final coldStartSecuredProfile = SecuredProfilePatch(
-      patchConfig: resolvedColdStartPatchConfig,
-      metadata: compiledRuntimePlan.securedProfile.metadata,
-      runtimeConstraints: _resolveColdStartRuntimeConstraints(
-        runtimeConstraints:
-            compiledRuntimePlan.securedProfile.runtimeConstraints,
-        coldStartPatchConfig: resolvedColdStartPatchConfig,
-      ),
-    );
-    final coldStartRuntimePlan = await _buildRuntimePlan(
-      rawProfile: compiledRuntimePlan.rawProfile,
-      securedProfile: coldStartSecuredProfile,
-      runtimePatchConfig: resolvedColdStartPatchConfig,
-    );
-    final resolvedRuntime =
-        _resolveRuntimeSelection(coldStartRuntimePlan.runtime);
-    await resolvedRuntime.engine.adapter.persistColdStart(
+    await compiledRuntimePlan.resolvedRuntime.engine.adapter.persistColdStart(
       initParams: await _buildInitParams(),
       runtimePlan: coldStartRuntimePlan,
       state: _buildCoreState(
@@ -614,19 +631,30 @@ class EngineManager {
     );
   }
 
-  ClashConfig _resolveColdStartPatchConfig({
-    required ClashConfig runtimePatchConfig,
-    required ClashConfig coldStartPatchConfig,
-  }) =>
-      runtimePatchConfig.copyWith.tun(enable: coldStartPatchConfig.tun.enable);
-
-  RuntimeSecurityConstraints _resolveColdStartRuntimeConstraints({
-    required RuntimeSecurityConstraints runtimeConstraints,
-    required ClashConfig coldStartPatchConfig,
-  }) =>
-      coldStartPatchConfig.tun.enable
-          ? runtimeConstraints
-          : const RuntimeSecurityConstraints();
+  RuntimePlan _deriveColdStartRuntimePlan(
+    RuntimePlan runtimePlan,
+    ClashConfig coldStartPatchConfig,
+  ) {
+    final config = Map<String, dynamic>.from(runtimePlan.config);
+    final tun = switch (config["tun"]) {
+      final Map<dynamic, dynamic> value => <String, dynamic>{
+          for (final entry in value.entries) entry.key.toString(): entry.value,
+        },
+      _ => <String, dynamic>{},
+    };
+    tun["enable"] = coldStartPatchConfig.tun.enable;
+    config["tun"] = tun;
+    return RuntimePlan(
+      config: config,
+      selectedMap: runtimePlan.selectedMap,
+      testUrl: runtimePlan.testUrl,
+      runtime: runtimePlan.runtime,
+      files: runtimePlan.files,
+      builtInProxyNodes: runtimePlan.builtInProxyNodes,
+      metadata: runtimePlan.metadata,
+      profileAccessControl: runtimePlan.profileAccessControl,
+    );
+  }
 
   void _syncCachedRuntimePlanWithUpdate(UpdateParams updateParams) {
     final compiledRuntimePlan = _lastCompiledRuntimePlan;
@@ -659,6 +687,43 @@ class EngineManager {
         runtimeConstraints:
             compiledRuntimePlan.securedProfile.runtimeConstraints,
       ),
+      requestedPatchConfig: updatedPatchConfig,
+      settingsRevision: compiledRuntimePlan.settingsRevision,
+    );
+  }
+
+  void _syncCachedRuntimePlanWithProxySelection(
+    String groupName,
+    String proxyName,
+  ) {
+    final compiledRuntimePlan = _lastCompiledRuntimePlan;
+    if (compiledRuntimePlan == null) {
+      return;
+    }
+    final currentPlan = compiledRuntimePlan.appliedRuntimePlan.runtimePlan;
+    if (currentPlan.selectedMap[groupName] == proxyName) {
+      return;
+    }
+    final updatedPlan = RuntimePlan(
+      config: currentPlan.config,
+      selectedMap: {...currentPlan.selectedMap, groupName: proxyName},
+      testUrl: currentPlan.testUrl,
+      runtime: currentPlan.runtime,
+      files: currentPlan.files,
+      builtInProxyNodes: currentPlan.builtInProxyNodes,
+      metadata: currentPlan.metadata,
+      profileAccessControl: currentPlan.profileAccessControl,
+    );
+    _lastCompiledRuntimePlan = _CompiledRuntimePlan(
+      appliedRuntimePlan: AppliedRuntimePlan(
+        patchConfig: compiledRuntimePlan.appliedRuntimePlan.patchConfig,
+        runtimePlan: updatedPlan,
+      ),
+      resolvedRuntime: compiledRuntimePlan.resolvedRuntime,
+      rawProfile: compiledRuntimePlan.rawProfile,
+      securedProfile: compiledRuntimePlan.securedProfile,
+      requestedPatchConfig: compiledRuntimePlan.requestedPatchConfig,
+      settingsRevision: compiledRuntimePlan.settingsRevision,
     );
   }
 

--- a/lib/product/services/android_shell_service.dart
+++ b/lib/product/services/android_shell_service.dart
@@ -7,13 +7,15 @@ import '../android/android_foreground_notification_policy.dart';
 import '../android/android_shell_bridge.dart';
 
 class AndroidShellService {
-  const AndroidShellService({
+  AndroidShellService({
     this.platform = const AndroidShellBridge(),
     this.foregroundNotification = const AndroidForegroundNotificationPolicy(),
   });
 
   final AndroidShellPlatformBridge platform;
   final AndroidForegroundNotificationPolicy foregroundNotification;
+  Future<void> _notificationPushChain = Future<void>.value();
+  String? _lastForegroundNotificationTitle;
 
   void bindTileCommands({
     AndroidTileStartHandler? onStart,
@@ -67,8 +69,20 @@ class AndroidShellService {
   }) =>
       foregroundNotification.buildTitle(profile, groups: groups);
 
-  Future<void> pushForegroundNotificationTitle(String title) =>
-      platform.pushForegroundNotificationTitle(title);
+  Future<void> pushForegroundNotificationTitle(String title) {
+    if (title.isEmpty) {
+      return Future<void>.value();
+    }
+    final push = _notificationPushChain.then((_) async {
+      if (_lastForegroundNotificationTitle == title) {
+        return;
+      }
+      await platform.pushForegroundNotificationTitle(title);
+      _lastForegroundNotificationTitle = title;
+    });
+    _notificationPushChain = push.catchError((_) {});
+    return push;
+  }
 
   Future<void> syncForegroundNotification({
     required Profile? profile,

--- a/lib/product/services/app_update_service.dart
+++ b/lib/product/services/app_update_service.dart
@@ -142,7 +142,7 @@ class AppUpdateService {
       tempFile.deleteSync();
     }
 
-    await platform.showDownloadProgress<void>(
+    final actualSha256 = await platform.showDownloadProgress<String>(
       release: release,
       asset: androidAsset.apkAsset,
       downloadTask: (onReceiveProgress) => platform.downloadReleaseAsset(
@@ -153,7 +153,6 @@ class AppUpdateService {
       ),
     );
 
-    final actualSha256 = await computeFileSha256(tempFile);
     if (actualSha256 != expectedSha256) {
       await tempFile.delete();
       throw StateError(

--- a/lib/product/services/product_services.dart
+++ b/lib/product/services/product_services.dart
@@ -9,15 +9,15 @@ export 'app_update_service.dart';
 export 'product_contributors.dart';
 
 class ProductServices {
-  const ProductServices({
+  ProductServices({
     this.accessControl = const AccessControlService(),
-    this.androidShell = const AndroidShellService(),
+    AndroidShellService? androidShell,
     this.appUpdate = const AppUpdateService(),
-  });
+  }) : androidShell = androidShell ?? AndroidShellService();
 
   final AccessControlService accessControl;
   final AndroidShellService androidShell;
   final AppUpdateService appUpdate;
 }
 
-const productServices = ProductServices();
+final productServices = ProductServices();

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi' show Pointer;
-import 'dart:io' show Platform;
+import 'dart:io' show File, Platform;
 
 import 'package:animations/animations.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -17,7 +17,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_js/flutter_js.dart';
 import 'package:material_color_utilities/palettes/core_palette.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:path/path.dart' as p;
 import 'package:url_launcher/url_launcher.dart';
 
 import 'common/common.dart';
@@ -125,6 +124,7 @@ class GlobalState {
   Map<String, dynamic>? lastRuntimeConfig;
   final activeProfileAccessControlNotifier =
       ValueNotifier<AccessControl?>(null);
+  final _loadedProfiles = LoadedProfileRepository();
   // Effective external-controller endpoint after applying the advisory/profile
   // merge rules for the active profile. Empty string means disabled.
   final effectiveExternalController = ValueNotifier<String>("");
@@ -378,15 +378,45 @@ class GlobalState {
   Future<RawProfile?> loadCurrentRawProfile() async {
     final profile = config.currentProfile;
     if (profile == null) {
+      _loadedProfiles.clear();
       return null;
     }
     final profilePath = await appPath.getProfilePath(profile.id);
-    final rawConfig = await handleEvaluate(
-      await loadProfileConfigFromFile(profilePath),
+    final profileStat = await File(profilePath).stat();
+    final currentScript = config.scriptProps.currentScript;
+    final revision = RawProfileRevision(
+      profileId: profile.id,
+      overrideData: profile.overrideData,
+      lastModifiedMicros: profileStat.modified.microsecondsSinceEpoch,
+      changedMicros: profileStat.changed.microsecondsSinceEpoch,
+      fileSize: profileStat.size,
+      scriptId: currentScript?.id,
+      scriptContent: currentScript?.content,
     );
-    return RawProfile.fromConfig(
-      profile: profile,
-      config: rawConfig,
+    return _loadedProfiles.load(revision, () async {
+      final rawConfig = await handleEvaluate(
+        await loadProfileConfigFromFile(profilePath),
+      );
+      return RawProfile.fromConfig(
+        profile: profile,
+        config: rawConfig,
+        revision: revision,
+      );
+    });
+  }
+
+  Object get runtimePlanSettingsRevision {
+    final selectedEntries =
+        (config.currentProfile?.selectedMap.entries.toList() ?? [])
+          ..sort((left, right) => left.key.compareTo(right.key));
+    return (
+      config.appSetting.overrideNetworkSettings,
+      config.overrideDns,
+      config.networkProps.routeMode,
+      config.appSetting.testUrl,
+      json.encode([
+        for (final entry in selectedEntries) [entry.key, entry.value],
+      ]),
     );
   }
 
@@ -603,18 +633,22 @@ class GlobalState {
     }
     final configJs = json.encode(config);
     final runtime = getJavascriptRuntime();
-    final res = await runtime.evaluateAsync("""
-      ${currentScript.content}
-      main($configJs)
-    """);
-    if (res.isError) {
-      throw res.stringResult;
+    try {
+      final res = await runtime.evaluateAsync("""
+        ${currentScript.content}
+        main($configJs)
+      """);
+      if (res.isError) {
+        throw res.stringResult;
+      }
+      final value = switch (res.rawResult is Pointer) {
+        true => runtime.convertValue<Map<String, dynamic>>(res),
+        false => Map<String, dynamic>.from(res.rawResult),
+      };
+      return value ?? config;
+    } finally {
+      runtime.dispose();
     }
-    final value = switch (res.rawResult is Pointer) {
-      true => runtime.convertValue<Map<String, dynamic>>(res),
-      false => Map<String, dynamic>.from(res.rawResult),
-    };
-    return value ?? config;
   }
 }
 

--- a/lib/views/connection/requests.dart
+++ b/lib/views/connection/requests.dart
@@ -32,7 +32,6 @@ class _LogConnectionsBodyState extends ConsumerState<LogConnectionsBody> {
   List<Connection> _requests = [];
   final _tag = CacheTag.requests;
   late ScrollController _scrollController;
-  bool _isLoad = false;
 
   @override
   void initState() {
@@ -44,7 +43,6 @@ class _LogConnectionsBodyState extends ConsumerState<LogConnectionsBody> {
     _requests = globalState.appState.requests.list;
     _requestsStateNotifier = ValueNotifier<ConnectionsState>(
       ConnectionsState(
-        loading: true,
         connections: _requests,
         query: widget.query,
         keywords: widget.keywords,
@@ -102,66 +100,14 @@ class _LogConnectionsBodyState extends ConsumerState<LogConnectionsBody> {
     }, duration: commonDuration);
   }
 
-  void _preLoad() {
-    if (_isLoad == true) {
-      return;
-    }
-    _isLoad = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!mounted) {
-        return;
-      }
-      final isMobileView = ref.read(isMobileViewProvider);
-      if (isMobileView) {
-        await Future.delayed(const Duration(milliseconds: 300));
-      }
-      final parts = _requests.batch(10);
-      globalState.cacheHeightMap[_tag] ??= FixedMap(
-        _requests.length,
-      );
-      for (var i = 0; i < parts.length; i++) {
-        final part = parts[i];
-        await Future(
-          () {
-            for (final request in part) {
-              globalState.cacheHeightMap[_tag]?.updateCacheValue(
-                request.id,
-                () => _calcCacheHeight(request),
-              );
-            }
-          },
-        );
-      }
-      _requestsStateNotifier.value = _requestsStateNotifier.value.copyWith(
-        loading: false,
-      );
-    });
-  }
-
   @override
   Widget build(BuildContext context) => TextScaleNotification(
         child: ValueListenableBuilder<ConnectionsState>(
           valueListenable: _requestsStateNotifier,
           builder: (_, state, __) {
-            _preLoad();
             final connections = state.list;
-            final items = connections
-                .map<Widget>(
-                  (connection) => ConnectionRow(
-                    key: Key(connection.id),
-                    connection: connection,
-                    mode: ConnectionRowMode.log,
-                    onClickKeyword: (value) {
-                      context.commonScaffoldState?.addKeyword(value);
-                    },
-                  ),
-                )
-                .separated(
-                  const Divider(
-                    height: 0,
-                  ),
-                )
-                .toList();
+            final itemCount =
+                connections.isEmpty ? 0 : connections.length * 2 - 1;
             final content = connections.isEmpty
                 ? NullStatus(
                     label: appLocalizations
@@ -187,8 +133,21 @@ class _LogConnectionsBodyState extends ConsumerState<LogConnectionsBody> {
                             }
                             return _calcCacheHeight(connections[index ~/ 2]);
                           },
-                          itemBuilder: (_, index) => items[index],
-                          itemCount: items.length,
+                          itemBuilder: (_, index) {
+                            if (index.isOdd) {
+                              return const Divider(height: 0);
+                            }
+                            final connection = connections[index ~/ 2];
+                            return ConnectionRow(
+                              key: Key(connection.id),
+                              connection: connection,
+                              mode: ConnectionRowMode.log,
+                              onClickKeyword: (value) {
+                                context.commonScaffoldState?.addKeyword(value);
+                              },
+                            );
+                          },
+                          itemCount: itemCount,
                           keyBuilder: (index) {
                             if (index.isOdd) {
                               return "divider";

--- a/lib/views/dashboard/dashboard.dart
+++ b/lib/views/dashboard/dashboard.dart
@@ -5,6 +5,7 @@ import 'package:flclashx/common/common.dart';
 import 'package:flclashx/enum/enum.dart';
 import 'package:flclashx/providers/providers.dart';
 import 'package:flclashx/widgets/widgets.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -41,6 +42,7 @@ class _DashboardViewState extends ConsumerState<DashboardView> with PageMixin {
   @override
   void dispose() {
     _isEditNotifier.dispose();
+    _addedWidgetsNotifier.dispose();
     super.dispose();
   }
 
@@ -191,12 +193,15 @@ class _DashboardViewState extends ConsumerState<DashboardView> with PageMixin {
           ),
     ];
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _addedWidgetsNotifier.value = DashboardWidget.values
+      final addedWidgets = DashboardWidget.values
           .where(
             (item) => !children.contains(item.widget) && isAllowed(item),
           )
           .map((item) => item.widget)
           .toList();
+      if (!listEquals(_addedWidgetsNotifier.value, addedWidgets)) {
+        _addedWidgetsNotifier.value = addedWidgets;
+      }
     });
     return Column(
       children: [

--- a/lib/views/dashboard/widgets/memory_info.dart
+++ b/lib/views/dashboard/widgets/memory_info.dart
@@ -3,23 +3,26 @@ import 'dart:io';
 
 import 'package:flclashx/clash/clash.dart';
 import 'package:flclashx/common/common.dart';
+import 'package:flclashx/enum/enum.dart';
 import 'package:flclashx/models/common.dart';
+import 'package:flclashx/providers/providers.dart';
 import 'package:flclashx/state.dart';
 import 'package:flclashx/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final _memoryInfoStateNotifier = ValueNotifier<TrafficValue>(
   const TrafficValue(value: 0),
 );
 
-class MemoryInfo extends StatefulWidget {
+class MemoryInfo extends ConsumerStatefulWidget {
   const MemoryInfo({super.key});
 
   @override
-  State<MemoryInfo> createState() => _MemoryInfoState();
+  ConsumerState<MemoryInfo> createState() => _MemoryInfoState();
 }
 
-class _MemoryInfoState extends State<MemoryInfo> {
+class _MemoryInfoState extends ConsumerState<MemoryInfo> {
   Timer? timer;
 
   @override
@@ -37,10 +40,13 @@ class _MemoryInfoState extends State<MemoryInfo> {
   Future<void> _updateMemory() async {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      final rss = ProcessInfo.currentRss;
-      _memoryInfoStateNotifier.value = TrafficValue(
-        value: clashLib != null ? rss : await clashCore.getMemory() + rss,
-      );
+      if (ref.read(isCurrentPageProvider(PageLabel.dashboard))) {
+        final rss = ProcessInfo.currentRss;
+        final value = clashLib != null ? rss : await clashCore.getMemory() + rss;
+        if (_memoryInfoStateNotifier.value.value != value) {
+          _memoryInfoStateNotifier.value = TrafficValue(value: value);
+        }
+      }
       timer = Timer(const Duration(seconds: 2), () async {
         _updateMemory();
       });

--- a/lib/views/logs.dart
+++ b/lib/views/logs.dart
@@ -17,13 +17,12 @@ class LogsView extends ConsumerStatefulWidget {
 
 class _LogsViewState extends ConsumerState<LogsView> with PageMixin {
   final _logsStateNotifier = ValueNotifier<LogsState>(
-    const LogsState(loading: true),
+    const LogsState(),
   );
   late ScrollController _scrollController;
 
   double _currentMaxWidth = 0;
   final _tag = CacheTag.rules;
-  bool _isLoad = false;
 
   List<Log> _logs = [];
 
@@ -143,42 +142,6 @@ class _LogsViewState extends ConsumerState<LogsView> with PageMixin {
     }, duration: commonDuration);
   }
 
-  void _preLoad() {
-    if (_isLoad == true) {
-      return;
-    }
-    _isLoad = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!mounted) {
-        return;
-      }
-      final isMobileView = ref.read(isMobileViewProvider);
-      if (isMobileView) {
-        await Future.delayed(const Duration(milliseconds: 300));
-      }
-      final parts = _logs.batch(10);
-      globalState.cacheHeightMap[_tag] ??= FixedMap(
-        _logs.length,
-      );
-      for (var i = 0; i < parts.length; i++) {
-        final part = parts[i];
-        await Future(
-          () {
-            for (final log in part) {
-              globalState.cacheHeightMap[_tag]?.updateCacheValue(
-                log.payload,
-                () => _getItemHeight(log),
-              );
-            }
-          },
-        );
-      }
-      _logsStateNotifier.value = _logsStateNotifier.value.copyWith(
-        loading: false,
-      );
-    });
-  }
-
   @override
   Widget build(BuildContext context) => LayoutBuilder(
         builder: (_, constraints) {
@@ -186,24 +149,8 @@ class _LogsViewState extends ConsumerState<LogsView> with PageMixin {
           return ValueListenableBuilder<LogsState>(
             valueListenable: _logsStateNotifier,
             builder: (_, state, __) {
-              _preLoad();
               final logs = state.list;
-              final items = logs
-                  .map<Widget>(
-                    (log) => LogItem(
-                      key: Key(log.dateTime),
-                      log: log,
-                      onClick: (value) {
-                        context.commonScaffoldState?.addKeyword(value);
-                      },
-                    ),
-                  )
-                  .separated(
-                    const Divider(
-                      height: 0,
-                    ),
-                  )
-                  .toList();
+              final itemCount = logs.isEmpty ? 0 : logs.length * 2 - 1;
               final content = logs.isEmpty
                   ? NullStatus(
                       label: appLocalizations.nullTip(
@@ -224,14 +171,27 @@ class _LogsViewState extends ConsumerState<LogsView> with PageMixin {
                             shrinkWrap: true,
                             physics: const NextClampingScrollPhysics(),
                             controller: _scrollController,
-                            itemBuilder: (_, index) => items[index],
+                            itemBuilder: (_, index) {
+                              if (index.isOdd) {
+                                return const Divider(height: 0);
+                              }
+                              final log = logs[index ~/ 2];
+                              return LogItem(
+                                key: Key(log.dateTime),
+                                log: log,
+                                onClick: (value) {
+                                  context.commonScaffoldState
+                                      ?.addKeyword(value);
+                                },
+                              );
+                            },
                             itemExtentBuilder: (index) {
                               if (index.isOdd) {
                                 return 0;
                               }
                               return _getItemHeight(logs[index ~/ 2]);
                             },
-                            itemCount: items.length,
+                            itemCount: itemCount,
                             keyBuilder: (index) {
                               if (index.isOdd) {
                                 return "divider";

--- a/lib/views/proxies/list.dart
+++ b/lib/views/proxies/list.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flclashx/common/common.dart';
 import 'package:flclashx/enum/enum.dart';
 import 'package:flclashx/models/models.dart';
@@ -15,8 +13,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'card.dart';
 import 'common.dart';
 
-typedef GroupNameProxiesMap = Map<String, List<Proxy>>;
-
 class ProxiesListView extends StatefulWidget {
   const ProxiesListView({super.key});
 
@@ -26,48 +22,13 @@ class ProxiesListView extends StatefulWidget {
 
 class _ProxiesListViewState extends State<ProxiesListView> {
   final _controller = ScrollController();
-  final _headerStateNotifier = ValueNotifier<ProxiesListHeaderSelectorState>(
-    const ProxiesListHeaderSelectorState(
-      offset: 0,
-      currentIndex: 0,
-    ),
-  );
-  final List<double> _headerOffset = [];
-  GroupNameProxiesMap _lastGroupNameProxiesMap = {};
 
   int _lastGroupsVersion = 0;
   List<String> _lastGroupNames = [];
 
   @override
-  void initState() {
-    super.initState();
-    _controller.addListener(_adjustHeader);
-  }
-
-  void _adjustHeader() {
-    final offset = _controller.offset;
-    final index = _headerOffset.findInterval(offset);
-    final currentIndex = index;
-    var headerOffset = 0.0;
-    if (index + 1 <= _headerOffset.length - 1) {
-      final endOffset = _headerOffset[index + 1];
-      final startOffset = endOffset - listHeaderHeight - 8;
-      if (offset > startOffset && offset < endOffset) {
-        headerOffset = offset - startOffset;
-      }
-    }
-    _headerStateNotifier.value = _headerStateNotifier.value.copyWith(
-      currentIndex: currentIndex,
-      offset: max(headerOffset, 0),
-    );
-  }
-
-  @override
   void dispose() {
-    _headerStateNotifier.dispose();
-    _controller
-      ..removeListener(_adjustHeader)
-      ..dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -75,12 +36,10 @@ class _ProxiesListViewState extends State<ProxiesListView> {
     WidgetRef ref, {
     required List<String> groupNames,
     required int columns,
-    required Set<String> currentUnfoldSet,
     required ProxyCardType type,
     required String query,
   }) {
     final items = <Widget>[];
-    final groupNameProxiesMap = <String, List<Proxy>>{};
     for (final groupName in groupNames) {
       final group = ref.watch(
         groupsProvider.select(
@@ -90,58 +49,16 @@ class _ProxiesListViewState extends State<ProxiesListView> {
       if (group == null) {
         continue;
       }
-      final sortedProxies = globalState.appController.getSortProxies(
-        group.all
-            .where((item) => item.name.toLowerCase().contains(query))
-            .toList(),
-        group.testUrl,
+      items.add(
+        ProxyGroupCard(
+          key: ValueKey(groupName),
+          group: group,
+          columns: columns,
+          type: type,
+          query: query,
+        ),
       );
-      groupNameProxiesMap[groupName] = sortedProxies;
-      final chunks = sortedProxies.chunks(columns);
-      final rows = chunks
-          .map<Widget>((proxies) {
-            final children = proxies
-                .map<Widget>(
-                  (proxy) => Flexible(
-                    flex: 1,
-                    child: RepaintBoundary(
-                      child: ProxyCard(
-                        testUrl: group.testUrl,
-                        type: type,
-                        groupType: group.type,
-                        key: ValueKey('$groupName.${proxy.name}'),
-                        proxy: proxy,
-                        groupName: groupName,
-                      ),
-                    ),
-                  ),
-                )
-                .fill(
-                  columns,
-                  filler: (_) => const Flexible(
-                    child: SizedBox(),
-                  ),
-                )
-                .separated(
-                  const SizedBox(
-                    width: 8,
-                  ),
-                );
-
-            return Row(
-              children: children.toList(),
-            );
-          })
-          .separated(
-            SizedBox(
-              height: type == ProxyCardType.oneline ? 4 : 8,
-            ),
-          )
-          .toList();
-
-      items.add(ProxyGroupCard(group: group, proxies: rows));
     }
-    _lastGroupNameProxiesMap = groupNameProxiesMap;
     return items;
   }
 
@@ -159,8 +76,6 @@ class _ProxiesListViewState extends State<ProxiesListView> {
           _lastGroupsVersion = groupsVersion;
           _lastGroupNames = state.groupNames;
 
-          _lastGroupNameProxiesMap.clear();
-
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted) {
               setState(() {});
@@ -176,7 +91,6 @@ class _ProxiesListViewState extends State<ProxiesListView> {
         final items = _buildItems(
           ref,
           groupNames: state.groupNames,
-          currentUnfoldSet: state.currentUnfoldSet,
           columns: state.columns,
           type: state.proxyCardType,
           query: state.query,
@@ -213,20 +127,25 @@ class ProxyGroupCard extends StatefulWidget {
   const ProxyGroupCard({
     super.key,
     required this.group,
-    required this.proxies,
+    required this.columns,
+    required this.type,
+    required this.query,
   });
   final Group group;
-  final List<Widget> proxies;
+  final int columns;
+  final ProxyCardType type;
+  final String query;
 
   @override
   State<ProxyGroupCard> createState() => _ProxyGroupCardState();
 }
 
-class _ProxyGroupCardState extends State<ProxyGroupCard>
-    with AutomaticKeepAliveClientMixin {
+class _ProxyGroupCardState extends State<ProxyGroupCard> {
   final _expansibleController = ExpansibleController();
 
   bool isLock = false;
+  bool _bodyMounted = false;
+  late List<Proxy> _sortedProxies;
 
   String get icon => widget.group.icon;
 
@@ -234,6 +153,39 @@ class _ProxyGroupCardState extends State<ProxyGroupCard>
 
   bool get isExpand => _expansibleController.isExpanded;
 
+  List<Proxy> _resolveProxies() =>
+      globalState.appController.getSortProxies(
+        widget.group.all
+            .where(
+              (item) => item.name.toLowerCase().contains(widget.query),
+            )
+            .toList(),
+        widget.group.testUrl,
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    _sortedProxies = _resolveProxies();
+  }
+
+  @override
+  void didUpdateWidget(ProxyGroupCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.group != widget.group ||
+        oldWidget.query != widget.query) {
+      _sortedProxies = _resolveProxies();
+    }
+  }
+
+  void _collapseAndReleaseBody() {
+    _expansibleController.collapse();
+    Future<void>.delayed(kThemeAnimationDuration, () {
+      if (mounted && !_expansibleController.isExpanded) {
+        setState(() => _bodyMounted = false);
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -246,9 +198,10 @@ class _ProxyGroupCardState extends State<ProxyGroupCard>
     final unfoldSet = Set<String>.from(currentUnfoldSet);
     
     if (_expansibleController.isExpanded) {
-      _expansibleController.collapse();
+      _collapseAndReleaseBody();
       unfoldSet.remove(groupName);
     } else {
+      setState(() => _bodyMounted = true);
       _expansibleController.expand();
       unfoldSet.add(groupName);
     }
@@ -303,20 +256,54 @@ class _ProxyGroupCardState extends State<ProxyGroupCard>
       },
     );
 
+  List<Widget> _buildProxyRows() => _sortedProxies
+      .chunks(widget.columns)
+      .map<Widget>((proxies) {
+        final children = proxies
+            .map<Widget>(
+              (proxy) => Flexible(
+                flex: 1,
+                child: RepaintBoundary(
+                  child: ProxyCard(
+                    testUrl: widget.group.testUrl,
+                    type: widget.type,
+                    groupType: widget.group.type,
+                    key: ValueKey('$groupName.${proxy.name}'),
+                    proxy: proxy,
+                    groupName: groupName,
+                  ),
+                ),
+              ),
+            )
+            .fill(
+              widget.columns,
+              filler: (_) => const Flexible(child: SizedBox()),
+            )
+            .separated(const SizedBox(width: 8));
+        return Row(children: children.toList());
+      })
+      .separated(
+        SizedBox(
+          height: widget.type == ProxyCardType.oneline ? 4 : 8,
+        ),
+      )
+      .toList();
+
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     final colorScheme = context.colorScheme;
     return Consumer(
       builder: (_, ref, __) {
         final unfoldSet = ref.watch(unfoldSetProvider);
         final shouldExpand = unfoldSet.contains(groupName);
+        final mountBody = _bodyMounted || shouldExpand;
         
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (shouldExpand && !_expansibleController.isExpanded) {
+            _bodyMounted = true;
             _expansibleController.expand();
           } else if (!shouldExpand && _expansibleController.isExpanded) {
-            _expansibleController.collapse();
+            _collapseAndReleaseBody();
           }
         });
         
@@ -432,7 +419,10 @@ class _ProxyGroupCardState extends State<ProxyGroupCard>
                       opacity: animation,
                       child: Container(
                         margin: const EdgeInsets.symmetric(vertical: 4.0),
-                        child: Column(children: widget.proxies),
+                        child: Column(
+                          children:
+                              mountBody ? _buildProxyRows() : const [],
+                        ),
                       ),
                     ),
                   ),
@@ -445,7 +435,4 @@ class _ProxyGroupCardState extends State<ProxyGroupCard>
       },
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/widgets/flag.dart
+++ b/lib/widgets/flag.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flclashx/clash/clash.dart';
 import 'package:flclashx/models/models.dart';
@@ -31,10 +32,61 @@ String? flagToCountryCode(String text) {
 }
 
 // destIP -> ISO country, cached so the 2s connections re-poll doesn't repeat geoip.
-final Map<String, String> _ipCountryCache = {};
+const _maxIpCountryCacheEntries = 512;
+final LinkedHashMap<String, String> _ipCountryCache = LinkedHashMap();
+final Map<String, Future<String>> _ipCountryInFlight = {};
 // Serialize geoip lookups so a single list build can't flood the core IPC channel
 // with a burst of requests (which would compete with the connections/traffic polls).
 Future<void> _geoipQueue = Future.value();
+
+String? _readCachedCountry(String ip) {
+  final value = _ipCountryCache.remove(ip);
+  if (value != null) {
+    _ipCountryCache[ip] = value;
+  }
+  return value;
+}
+
+void _cacheCountry(String ip, String country) {
+  _ipCountryCache.remove(ip);
+  _ipCountryCache[ip] = country;
+  while (_ipCountryCache.length > _maxIpCountryCacheEntries) {
+    _ipCountryCache.remove(_ipCountryCache.keys.first);
+  }
+}
+
+Future<String> _resolveCountry(String ip) {
+  final cached = _readCachedCountry(ip);
+  if (cached != null) {
+    return Future.value(cached);
+  }
+  final inFlight = _ipCountryInFlight[ip];
+  if (inFlight != null) {
+    return inFlight;
+  }
+  final task = _geoipQueue.catchError((_) {}).then((_) async {
+    final queuedHit = _readCachedCountry(ip);
+    if (queuedHit != null) {
+      return queuedHit;
+    }
+    final info = await clashCore.getCountryCode(ip);
+    final country = info?.countryCode ?? '';
+    _cacheCountry(ip, country);
+    return country;
+  });
+  _geoipQueue = task.then<void>(
+    (_) {},
+    onError: (_, __) {},
+  );
+  _ipCountryInFlight[ip] = task;
+  unawaited(
+    task.then<void>(
+      (_) => _ipCountryInFlight.remove(ip),
+      onError: (_, __) => _ipCountryInFlight.remove(ip),
+    ),
+  );
+  return task;
+}
 
 /// The destination host's country, from the core's local geoip on the connection's
 /// destination IP. Cached per IP and looked up through a serial queue. In badge mode
@@ -82,24 +134,16 @@ class _ConnectionFlagState extends State<ConnectionFlag> {
       _set('');
       return;
     }
-    final cached = _ipCountryCache[ip];
-    if (cached != null) {
-      _set(cached);
-      return;
-    }
-    final completer = Completer<String>();
-    _geoipQueue = _geoipQueue.then((_) async {
-      final hit = _ipCountryCache[ip];
-      if (hit != null) {
-        completer.complete(hit);
-        return;
+    try {
+      final code = await _resolveCountry(ip);
+      if (widget.connection.metadata.destinationIP == ip) {
+        _set(code);
       }
-      final info = await clashCore.getCountryCode(ip);
-      final cc = info?.countryCode ?? '';
-      _ipCountryCache[ip] = cc;
-      completer.complete(cc);
-    });
-    _set(await completer.future);
+    } catch (_) {
+      if (widget.connection.metadata.destinationIP == ip) {
+        _set('');
+      }
+    }
   }
 
   void _set(String code) {

--- a/lib/widgets/line_chart.dart
+++ b/lib/widgets/line_chart.dart
@@ -160,14 +160,7 @@ class LineChartPainter extends CustomPainter {
   Path getAnimatedPath(Size size) {
     final interpolatedPoints =
         getInterpolatePoints(prevPoints, points, progress);
-    final path = getPath(interpolatedPoints, size);
-
-    final metric = path.computeMetrics().first;
-    final length = metric.length;
-    return metric.extractPath(
-      0,
-      length,
-    );
+    return getPath(interpolatedPoints, size);
   }
 
   @override

--- a/test/product/compile/loaded_profile_repository_test.dart
+++ b/test/product/compile/loaded_profile_repository_test.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'package:flclashx/models/models.dart';
+import 'package:flclashx/product/compile/product_compile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const profile = Profile(
+    id: 'profile-cache',
+    autoUpdateDuration: Duration.zero,
+  );
+  const revision = RawProfileRevision(
+    profileId: 'profile-cache',
+    overrideData: OverrideData(),
+    lastModifiedMicros: 10,
+    changedMicros: 11,
+    fileSize: 100,
+    scriptId: 'script-1',
+    scriptContent: 'v1',
+  );
+
+  test('shares one in-flight load and caches the exact revision', () async {
+    final repository = LoadedProfileRepository();
+    final completer = Completer<RawProfile>();
+    var calls = 0;
+
+    Future<RawProfile> loader() {
+      calls++;
+      return completer.future;
+    }
+
+    final first = repository.load(revision, loader);
+    final concurrent = repository.load(revision, loader);
+    completer.complete(
+      RawProfile.fromConfig(
+        profile: profile,
+        config: const {'proxies': []},
+        revision: revision,
+      ),
+    );
+    final loaded = await first;
+
+    expect(await concurrent, same(loaded));
+    expect(await repository.load(revision, loader), same(loaded));
+    expect(calls, 1);
+  });
+
+  test('clear prevents a stale in-flight load from repopulating cache',
+      () async {
+    final repository = LoadedProfileRepository();
+    final staleCompleter = Completer<RawProfile>();
+
+    final stale = repository.load(revision, () => staleCompleter.future);
+    repository.clear();
+    final fresh = repository.load(
+      revision,
+      () async => RawProfile.fromConfig(
+        profile: profile,
+        config: const {'revision': 'fresh'},
+        revision: revision,
+      ),
+    );
+    staleCompleter.complete(
+      RawProfile.fromConfig(
+        profile: profile,
+        config: const {'revision': 'stale'},
+        revision: revision,
+      ),
+    );
+
+    expect((await stale).config['revision'], 'stale');
+    expect((await fresh).config['revision'], 'fresh');
+    expect(
+      (await repository.load(
+        revision,
+        () => throw StateError('unexpected reload'),
+      ))
+          .config['revision'],
+      'fresh',
+    );
+  });
+
+  test('reloads when the profile revision changes', () async {
+    final repository = LoadedProfileRepository();
+    var calls = 0;
+
+    Future<RawProfile> load(RawProfileRevision currentRevision) async {
+      calls++;
+      return RawProfile.fromConfig(
+        profile: profile,
+        config: {'load': calls},
+        revision: currentRevision,
+      );
+    }
+
+    await repository.load(revision, () => load(revision));
+    final changedRevision = RawProfileRevision(
+      profileId: revision.profileId,
+      overrideData: revision.overrideData,
+      lastModifiedMicros: revision.lastModifiedMicros,
+      changedMicros: revision.changedMicros + 1,
+      fileSize: revision.fileSize,
+      scriptId: revision.scriptId,
+      scriptContent: revision.scriptContent,
+    );
+    final reloaded = await repository.load(
+      changedRevision,
+      () => load(changedRevision),
+    );
+
+    expect(reloaded.config['load'], 2);
+    expect(calls, 2);
+  });
+
+  test('freezes cached profile config deeply', () {
+    final profileConfig = <String, dynamic>{
+      'tun': <String, dynamic>{'enable': true},
+      'rules': <dynamic>['MATCH,DIRECT'],
+    };
+    final rawProfile = RawProfile.fromConfig(
+      profile: profile,
+      config: profileConfig,
+      revision: revision,
+    );
+
+    expect(
+      () => rawProfile.config['tun']['enable'] = false,
+      throwsUnsupportedError,
+    );
+    expect(
+      () => (rawProfile.config['rules'] as List).add('DOMAIN,test,DIRECT'),
+      throwsUnsupportedError,
+    );
+  });
+}

--- a/test/product/compile/profile_split_tunneling_test.dart
+++ b/test/product/compile/profile_split_tunneling_test.dart
@@ -320,6 +320,52 @@ void main() {
       );
     });
 
+    test('bounds parallel source reads and preserves source order', () async {
+      final profilesDir = Directory(path.join(tempDir.path, 'profiles'))
+        ..createSync(recursive: true);
+      final urls = [
+        for (var index = 0; index < 8; index++)
+          'https://example.com/list-$index.txt',
+      ];
+      var activeReads = 0;
+      var peakReads = 0;
+
+      final resolved = await resolveAndroidProfileSplitTunneling(
+        rawConfig: {
+          'tun': {
+            'include-package-url': urls,
+          },
+        },
+        isAndroid: true,
+        profilesPath: profilesDir.path,
+        profileId: 'profile-parallel-sources',
+        installedPackageNames: [
+          for (var index = 0; index < urls.length; index++) 'com.example.$index',
+        ],
+        readRemoteSource: (url) async {
+          final index = urls.indexOf(url);
+          activeReads++;
+          if (activeReads > peakReads) {
+            peakReads = activeReads;
+          }
+          try {
+            await Future<void>.delayed(
+              Duration(milliseconds: (urls.length - index) * 2),
+            );
+            return 'com.example.$index\n';
+          } finally {
+            activeReads--;
+          }
+        },
+      );
+
+      expect(peakReads, 4);
+      expect(
+        resolved.config['tun']['include-package'],
+        [for (var index = 0; index < urls.length; index++) 'com.example.$index'],
+      );
+    });
+
     test('rejects cache paths outside the profiles directory', () async {
       final profilesDir = Directory(path.join(tempDir.path, 'profiles'))
         ..createSync(recursive: true);

--- a/test/product/runtime/engine_manager_test.dart
+++ b/test/product/runtime/engine_manager_test.dart
@@ -494,6 +494,104 @@ void main() {
       expect(manager.activeEngineId, RuntimeId.mihomo);
     });
 
+    test('reuses a verified pending plan between init and setup', () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+      const request = EngineRuntimePlanRequest(
+        patchConfig: ClashConfig(),
+        settingsRevision: ('settings', 1),
+      );
+
+      await manager.initializeCore(
+        runtimePlanRequest: request,
+        coldStartPatchConfig: const ClashConfig(),
+        setupRuntimePlan: false,
+      );
+      await manager.setupRuntimePlan(request);
+
+      expect(buildCalls, 1);
+      expect(mihomoAdapter.setupRuntimePlanCalls, 1);
+    });
+
+    test('invalidates pending plan when compiler inputs change', () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+
+      await manager.initializeCore(
+        runtimePlanRequest: const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 1,
+        ),
+        coldStartPatchConfig: const ClashConfig(),
+        setupRuntimePlan: false,
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(
+          patchConfig: ClashConfig(),
+          settingsRevision: 2,
+        ),
+      );
+
+      expect(buildCalls, 2);
+    });
+
+    test('persists the latest proxy selection without rebuilding plan',
+        () async {
+      var buildCalls = 0;
+      manager = buildManager(
+        buildRuntimePlan: ({
+          required rawProfile,
+          required securedProfile,
+          required runtimePatchConfig,
+        }) async {
+          buildCalls++;
+          return RuntimePlan.empty(
+            selectedMap: const {'Auto': 'Node A'},
+            testUrl: 'https://example.com',
+            runtime: runtimeSelection,
+          );
+        },
+      );
+      await manager.setupRuntimePlan(
+        const EngineRuntimePlanRequest(patchConfig: ClashConfig()),
+      );
+
+      await manager.notifyProxySelected('Auto', 'Node B');
+      await manager.persistColdStart(pathConfig: const ClashConfig());
+
+      expect(buildCalls, 1);
+      expect(
+        mihomoAdapter.lastPersistedRuntimePlan?.selectedMap,
+        {'Auto': 'Node B'},
+      );
+    });
+
     test('rejects runtime switch while started', () async {
       final started = await manager.start();
       expect(started, isTrue);

--- a/test/product/services/android_shell_service_test.dart
+++ b/test/product/services/android_shell_service_test.dart
@@ -38,6 +38,20 @@ void main() {
       expect(bridge.pushedTitles, ['Service Name / Runtime Proxy']);
     });
 
+    test('does not push an unchanged foreground notification title', () async {
+      final bridge = _FakeAndroidShellPlatformBridge();
+      final service = AndroidShellService(platform: bridge);
+
+      await service.pushForegroundNotificationTitle('Profile / Node A');
+      await service.pushForegroundNotificationTitle('Profile / Node A');
+      await service.pushForegroundNotificationTitle('Profile / Node B');
+
+      expect(
+        bridge.pushedTitles,
+        ['Profile / Node A', 'Profile / Node B'],
+      );
+    });
+
     test('syncs proxy-change titles only for the tracked server group',
         () async {
       final bridge = _FakeAndroidShellPlatformBridge();

--- a/test/product/services/app_update_service_test.dart
+++ b/test/product/services/app_update_service_test.dart
@@ -91,7 +91,7 @@ class _FakeUpdateBridge implements AppUpdatePlatformBridge {
   Future<String?> readRemoteText(String url) async => remoteTexts[url];
 
   @override
-  Future<void> downloadReleaseAsset(
+  Future<String> downloadReleaseAsset(
     ReleaseAsset asset,
     String targetPath, {
     required String expectedSha256,
@@ -107,6 +107,11 @@ class _FakeUpdateBridge implements AppUpdatePlatformBridge {
     await file.parent.create(recursive: true);
     await file.writeAsBytes(bytes, flush: true);
     onReceiveProgress?.call(bytes.length, bytes.length);
+    final actualSha256 = sha256.convert(bytes).toString();
+    if (actualSha256 != expectedSha256) {
+      throw StateError('SHA256 verification failed for fake asset.');
+    }
+    return actualSha256;
   }
 
   @override

--- a/tool/base_drift_allowlist.json
+++ b/tool/base_drift_allowlist.json
@@ -491,6 +491,11 @@
       "reason": "Убран шумный отладочный лог TunStackItem; форматный дрейф откатан к апстриму."
     },
     {
+      "path": "lib/views/connection/requests.dart",
+      "bucket": "budget",
+      "reason": "Лента соединений строит только видимые строки и не выполняет предварительную загрузку фиксированных высот."
+    },
+    {
       "path": "lib/views/dashboard/dashboard.dart",
       "bucket": "budget",
       "reason": "Живой dashboard оставлен в base и держит только lock-гейты и выбор вида через продуктовые селекторы."
@@ -511,6 +516,11 @@
       "reason": "Живой metainfo-виджет читает support URL через product display hints и снова использует обычный URLFormDialog."
     },
     {
+      "path": "lib/views/dashboard/widgets/memory_info.dart",
+      "bucket": "budget",
+      "reason": "Опрос памяти выполняется только при видимом dashboard и не публикует неизменившееся значение."
+    },
+    {
       "path": "lib/views/dashboard/widgets/service_info_widget.dart",
       "bucket": "budget",
       "reason": "Живой service-info виджет берет брендовые поля и ссылку поддержки через product display hints."
@@ -529,6 +539,26 @@
       "path": "lib/views/profiles/receive_profile_dialog.dart",
       "bucket": "budget",
       "reason": "Запуск фонового сервера в initState помечен через unawaited, чтобы не терять Future."
+    },
+    {
+      "path": "lib/views/logs.dart",
+      "bucket": "budget",
+      "reason": "Лента логов строит элементы лениво и вычисляет высоты по запросу без полной предварительной загрузки."
+    },
+    {
+      "path": "lib/views/proxies/list.dart",
+      "bucket": "budget",
+      "reason": "Карточки прокси создаются только для смонтированных раскрытых групп; свёрнутые и ушедшие с экрана группы освобождают тяжёлые строки."
+    },
+    {
+      "path": "lib/widgets/flag.dart",
+      "bucket": "budget",
+      "reason": "GeoIP-кэш ограничен LRU-бюджетом, а одинаковые запросы объединяются и восстанавливаются после ошибок."
+    },
+    {
+      "path": "lib/widgets/line_chart.dart",
+      "bucket": "budget",
+      "reason": "График использует уже построенный Path без лишнего полного прохода по метрикам на каждом кадре."
     }
   ]
 }


### PR DESCRIPTION
## Что изменено

- Кэшируется точная ревизия загруженного профиля и повторно используется runtime-план между init/setup; изменение файла, скрипта, override, TUN или выбранного прокси инвалидирует нужный кэш.
- Убраны повторные копирования и проверки конфигурации, двойное SHA256 APK, неизменившиеся provider/notification updates и лишние Android PackageManager-запросы.
- Логи, соединения и группы прокси создают тяжёлые виджеты лениво; свёрнутые и ушедшие с экрана группы освобождаются.
- GeoIP-кэш ограничен LRU-бюджетом, одинаковые запросы объединены; опрос памяти не обращается к core вне dashboard.
- Источники split tunneling читаются параллельно с лимитом 4, порядок результата сохранён.
- Удалён неиспользуемый анализ китайских APK и зависимость smali-dexlib2.

## Границы безопасности

Частота polling, порядок пользовательских обновлений и security policy не менялись. Задержки, debounce и долгоживущие кэши из закрытого PR #40 не переносились; повторное использование разрешено только при полном совпадении входов.

## Проверки

- `flutter analyze --fatal-infos ...` — без замечаний.
- `flutter test test/product test/tool` — 314 тестов прошли.
- Product boundary, release continuity и base drift guards прошли.
- Собран arm64 release APK со всеми четырьмя нативными runtime-библиотеками: 72 124 849 байт против 72 166 521 байта до изменений.
