### PR TITLE
Добавить кнопку armeabi-v7a в описание пре-релиза

### DIFF
--- a/.github/pre_release_template.md
+++ b/.github/pre_release_template.md
@@ -8,8 +8,8 @@
 
 ### 📥 Скачать
 
-[![Universal APK](https://img.shields.io/badge/Universal_APK-2ea44f?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-universal.apk) [![arm64-v8a](https://img.shields.io/badge/arm64--v8a-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-arm64-v8a.apk)
+[![Universal APK](https://img.shields.io/badge/Universal_APK-2ea44f?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-universal.apk) [![arm64-v8a](https://img.shields.io/badge/arm64--v8a-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-arm64-v8a.apk) [![armeabi-v7a](https://img.shields.io/badge/armeabi--v7a-e36209?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-armeabi-v7a.apk)
 
-Не уверены — берите **Universal**. Другие варианты (`armeabi-v7a`, `x86_64`), AAB и файлы `.sha256` — во вложениях ниже.
+Не уверены — берите **Universal**. Другие варианты (`x86_64`), AAB и файлы `.sha256` — во вложениях ниже.
 
 📚 [Документация](https://github.com/REPO/blob/main/i18n/ru/docs/README.md) · 📄 [Все изменения](https://github.com/REPO/blob/main/CHANGELOG.md)


### PR DESCRIPTION
В разделе «Скачать» пре-релизов было только две кнопки — Universal и arm64-v8a. Добавляет третью кнопку `armeabi-v7a` (артефакт `FlClashM-android-armeabi-v7a.apk` уже входит в релиз, просто не имел бейджа).

`armeabi-v7a` убран из строки «другие варианты» — там остаётся `x86_64`, AAB и `.sha256`.

Затрагивает только `.github/pre_release_template.md`. `check_release_continuity.dart` проходит локально.