### PR TITLE
Добавить кнопку x86_64 и уравнять цвета кнопок в описании пре-релиза

### DIFF
--- a/.github/pre_release_template.md
+++ b/.github/pre_release_template.md
@@ -8,8 +8,8 @@
 
 ### 📥 Скачать
 
-[![Universal APK](https://img.shields.io/badge/Universal_APK-2ea44f?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-universal.apk) [![arm64-v8a](https://img.shields.io/badge/arm64--v8a-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-arm64-v8a.apk) [![armeabi-v7a](https://img.shields.io/badge/armeabi--v7a-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-armeabi-v7a.apk)
+[![Universal APK](https://img.shields.io/badge/Universal_APK-2ea44f?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-universal.apk) [![arm64-v8a](https://img.shields.io/badge/arm64--v8a-2ea44f?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-arm64-v8a.apk) [![armeabi-v7a](https://img.shields.io/badge/armeabi--v7a-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-armeabi-v7a.apk) [![x86_64](https://img.shields.io/badge/x86__64-1f6feb?style=for-the-badge&logo=android&logoColor=white)](https://github.com/REPO/releases/download/TAG/FlClashM-android-x86_64.apk)
 
-Не уверены — берите **Universal**. Другие варианты (`x86_64`), AAB и файлы `.sha256` — во вложениях ниже.
+Не уверены — берите **Universal**. AAB и файлы `.sha256` — во вложениях ниже.
 
 📚 [Документация](https://github.com/REPO/blob/main/i18n/ru/docs/README.md) · 📄 [Все изменения](https://github.com/REPO/blob/main/CHANGELOG.md)


### PR DESCRIPTION
В раздел «Скачать» пре-релизов добавлена четвёртая кнопка `x86_64` (артефакт `FlClashM-android-x86_64.apk` уже входит в релиз). Цвета приведены к схеме: Universal и arm64-v8a — зелёные (`2ea44f`), armeabi-v7a и x86_64 — синие (`1f6feb`).

`x86_64` убран из строки «другие варианты» — там остаётся AAB и `.sha256`.

Затрагивает только `.github/pre_release_template.md`. `check_release_continuity.dart` проходит локально.