### PR TITLE
feat: добавлена платформенная композиция приложения

### DIFF
--- a/lib/common/path.dart
+++ b/lib/common/path.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
+import 'dart:ffi' show Abi;
 import 'dart:io';
 
 import 'package:flclashx/common/common.dart';
+import 'package:flclashx/product/platform/product_install_layout.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class AppPath {
-
   factory AppPath() {
     _instance ??= AppPath._internal();
     return _instance!;
@@ -43,15 +44,36 @@ class AppPath {
     return dirname(currentExecutablePath);
   }
 
-  String get corePath {
-    if (Platform.isMacOS) {
-      // Core is stored in Application Support/com.follow.clash/cores/ (copied by Swift code on launch)
-      // Permissions are set automatically in Swift
-      final home = Platform.environment['HOME'] ?? '';
-      return '$home/Library/Application Support/com.follow.clash/cores/FlClashCore';
-    }
-    return join(executableDirPath, "FlClashCore$executableExtension");
-  }
+  String get desktopInstallRoot =>
+      Platform.isMacOS ? dirname(executableDirPath) : executableDirPath;
+
+  String get desktopArchitecture => switch (Abi.current()) {
+        Abi.linuxX64 || Abi.windowsX64 || Abi.macosX64 => 'x86_64',
+        Abi.linuxArm64 || Abi.windowsArm64 || Abi.macosArm64 => 'arm64',
+        _ => throw UnsupportedError(
+            'FlClashM has no runtime layout for `${Abi.current()}`.',
+          ),
+      };
+
+  String get _desktopRuntimeTarget => switch (Platform.operatingSystem) {
+        'linux' || 'windows' || 'macos' => Platform.operatingSystem,
+        _ => throw UnsupportedError(
+            'FlClashM has no desktop runtime for `${Platform.operatingSystem}`.',
+          ),
+      };
+
+  String _desktopArtifactPath(String artifact) =>
+      '${ProductInstallLayout.artifactPath(
+        installRoot: desktopInstallRoot,
+        target: _desktopRuntimeTarget,
+        architecture: desktopArchitecture,
+        artifact: artifact,
+      )}$executableExtension';
+
+  String get corePath =>
+      Platform.isLinux || Platform.isWindows || Platform.isMacOS
+          ? _desktopArtifactPath(ProductInstallLayout.mihomoArtifact)
+          : join(executableDirPath, "FlClashCore$executableExtension");
 
   String get corePendingPath => '$corePath.pending';
 
@@ -60,7 +82,10 @@ class AppPath {
   String get allowedCoreHashPath =>
       join(executableDirPath, "allowed_core.sha256");
 
-  String get helperPath => join(executableDirPath, "$appHelperService$executableExtension");
+  String get helperPath =>
+      Platform.isLinux || Platform.isWindows || Platform.isMacOS
+          ? _desktopArtifactPath(ProductInstallLayout.helperArtifact)
+          : join(executableDirPath, "$appHelperService$executableExtension");
 
   Future<String> get downloadDirPath async {
     final directory = await downloadDir.future;

--- a/lib/product/android/android_runtime_access_policy.dart
+++ b/lib/product/android/android_runtime_access_policy.dart
@@ -12,49 +12,9 @@ import '../../plugins/app.dart';
 import '../../plugins/vpn.dart';
 import '../runtime/engine_manager.dart';
 import '../runtime/vpn_access_control.dart';
+import '../services/runtime_access_platform.dart';
 
-@immutable
-class ProfileAccessSnapshot {
-  const ProfileAccessSnapshot.available(this.accessControl) : available = true;
-
-  const ProfileAccessSnapshot.unavailable()
-      : available = false,
-        accessControl = null;
-
-  final bool available;
-  final AccessControl? accessControl;
-}
-
-abstract interface class RuntimeAccessPlatformBridge {
-  bool get isAndroid;
-
-  Future<List<Package>> readPackages();
-
-  Future<ImageProvider?> readPackageIcon(String packageName);
-
-  String mergeVpnOptions(
-    String optionsJson, {
-    required AccessControl accessControl,
-  });
-
-  Future<bool> startVpn({required AccessControl accessControl});
-
-  Future<void> stopVpn();
-
-  /// Reads the immutable options snapshot used to establish the live Android
-  /// VPN. An available snapshot with null access control means that the VPN
-  /// explicitly has no profile package rule; unavailable means the remote
-  /// service could not provide a trustworthy snapshot.
-  Future<ProfileAccessSnapshot> readAppliedProfileAccess();
-
-  Future<ResolvedTunAccess> resolveTunAccess({
-    required bool requestedTunEnable,
-    required bool realTunEnable,
-    required Future<void> Function() onAuthorizeRestart,
-    required ValueChanged<bool> onResolvedTunEnable,
-    Future<AuthorizeCode> Function()? authorizeCore,
-  });
-}
+export '../services/runtime_access_platform.dart';
 
 class AndroidRuntimeAccessPolicy implements RuntimeAccessPlatformBridge {
   const AndroidRuntimeAccessPolicy({

--- a/lib/product/bootstrap/app_bootstrap.dart
+++ b/lib/product/bootstrap/app_bootstrap.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application.dart';
-import '../../clash/core.dart';
 import '../../common/http.dart';
 import '../../common/path.dart';
 import '../../common/system.dart';
@@ -30,7 +29,7 @@ class AppBootstrap {
     }
 
     final version = await system.version;
-    await clashCore.preload();
+    await composition.bootstrap.preloadMihomo();
     await globalState.initApp(version);
     await composition.bootstrap.initialize();
 

--- a/lib/product/bootstrap/app_bootstrap.dart
+++ b/lib/product/bootstrap/app_bootstrap.dart
@@ -5,14 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application.dart';
 import '../../clash/core.dart';
-import '../../common/android.dart';
 import '../../common/http.dart';
 import '../../common/path.dart';
 import '../../common/system.dart';
 import '../../state.dart';
-import '../android/android_entrypoint.dart';
 import '../diagnostics/diagnostic_recorder.dart';
-import '../platform/platform_profile.dart';
+import '../platform/product_platform_composition.dart';
 
 class AppBootstrap {
   const AppBootstrap._();
@@ -26,17 +24,15 @@ class AppBootstrap {
   }
 
   static Future<void> _runInitialized() async {
-    if (!productPlatform.supported) {
-      throw UnsupportedError(
-        'FlClashM is Android-only. Host platform: ${productPlatform.hostPlatform.name}',
-      );
+    final composition = productPlatformComposition;
+    if (!composition.profile.supported) {
+      throw UnsupportedError(composition.profile.unsupportedMessage);
     }
 
     final version = await system.version;
     await clashCore.preload();
     await globalState.initApp(version);
-    await android?.init();
-    await androidEntrypoint.init();
+    await composition.bootstrap.initialize();
 
     HttpOverrides.global = FlClashHttpOverrides();
     runApp(const ProviderScope(child: Application()));

--- a/lib/product/compile/product_profile_pipeline.dart
+++ b/lib/product/compile/product_profile_pipeline.dart
@@ -1,5 +1,6 @@
 import 'package:flclashx/models/models.dart';
 
+import '../platform/product_platform_composition.dart';
 import '../security/product_security.dart';
 import 'profile_compiler.dart';
 import 'raw_profile.dart';
@@ -8,11 +9,14 @@ import 'runtime_plan.dart';
 class ProductProfilePipeline {
   const ProductProfilePipeline({
     this.profileCompiler = const ProfileCompiler(),
-    this.securityPolicy = androidSecurityPolicy,
-  });
+    SecurityPolicy? securityPolicy,
+  }) : _securityPolicy = securityPolicy;
 
   final ProfileCompiler profileCompiler;
-  final SecurityPolicy securityPolicy;
+  final SecurityPolicy? _securityPolicy;
+
+  SecurityPolicy get securityPolicy =>
+      _securityPolicy ?? productPlatformComposition.securityPolicy;
 
   ClashConfig securePatchConfig({
     required ClashConfig patchConfig,

--- a/lib/product/platform/desktop_platform_services.dart
+++ b/lib/product/platform/desktop_platform_services.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+import '../../enum/enum.dart';
+import '../../models/models.dart';
+import '../runtime/engine_manager.dart';
+import '../services/product_shell_service.dart';
+import '../services/product_update_service.dart';
+import '../services/runtime_access_platform.dart';
+
+/// Capability that is intentionally absent until its platform PR lands.
+enum DesktopCapability { tun, helper, updateInstallation }
+
+String desktopCapabilityMessage(DesktopCapability capability) =>
+    switch (capability) {
+      DesktopCapability.tun =>
+        'Desktop TUN is not implemented for this platform yet.',
+      DesktopCapability.helper =>
+        'Desktop privileged helper is not implemented for this platform yet.',
+      DesktopCapability.updateInstallation =>
+        'Desktop update installation is not implemented for this platform yet.',
+    };
+
+class DesktopRuntimeAccessPolicy implements RuntimeAccessPlatformBridge {
+  const DesktopRuntimeAccessPolicy();
+
+  @override
+  bool get isAndroid => false;
+
+  @override
+  Future<List<Package>> readPackages() => Future.value(const []);
+
+  @override
+  Future<ImageProvider?> readPackageIcon(String packageName) =>
+      Future.value(null);
+
+  @override
+  String mergeVpnOptions(
+    String optionsJson, {
+    required AccessControl accessControl,
+  }) =>
+      optionsJson;
+
+  @override
+  Future<ProfileAccessSnapshot> readAppliedProfileAccess() =>
+      Future.value(const ProfileAccessSnapshot.available(null));
+
+  @override
+  Future<ResolvedTunAccess> resolveTunAccess({
+    required bool requestedTunEnable,
+    required bool realTunEnable,
+    required Future<void> Function() onAuthorizeRestart,
+    required ValueChanged<bool> onResolvedTunEnable,
+    Future<AuthorizeCode> Function()? authorizeCore,
+  }) =>
+      Future.error(
+          UnsupportedError(desktopCapabilityMessage(DesktopCapability.tun)));
+
+  @override
+  Future<bool> startVpn({required AccessControl accessControl}) => Future.error(
+      UnsupportedError(desktopCapabilityMessage(DesktopCapability.tun)));
+
+  @override
+  Future<void> stopVpn() => Future.error(
+      UnsupportedError(desktopCapabilityMessage(DesktopCapability.tun)));
+}
+
+/// A deliberately channel-free shell. Android-only lifecycle hooks are no-ops;
+/// actual privileged work remains unavailable through [DesktopCapability].
+class DesktopShellService implements ProductShellService {
+  const DesktopShellService();
+
+  @override
+  void bindTileCommands({
+    FutureOr<void> Function()? onStart,
+    FutureOr<void> Function()? onStop,
+    FutureOr<void> Function(String mode)? onChangeMode,
+  }) {}
+
+  @override
+  String buildForegroundNotificationTitle({
+    required Profile? profile,
+    Iterable<Group> groups = const [],
+  }) =>
+      profile?.label ?? 'FlClashM';
+
+  @override
+  Future<void> initShortcuts() async {}
+
+  @override
+  void installExitHook(FutureOr<void> Function() onExit) {}
+
+  @override
+  Future<void> moveTaskToBack() async {}
+
+  @override
+  Future<void> notifyNoProfileSelected() async {}
+
+  @override
+  Future<void> notifyRuntimeNotReady() async {}
+
+  @override
+  Future<void> notifyStartError(Object error) async {}
+
+  @override
+  Future<void> notifyStartRequested() async {}
+
+  @override
+  Future<void> notifyStopRequested() async {}
+
+  @override
+  Future<void> notifyVpnStartFailed() async {}
+
+  @override
+  Future<void> pushForegroundNotificationTitle(String title) async {}
+
+  @override
+  Future<void> showTip(String message) async {}
+
+  @override
+  Future<void> signalServiceReady() async {}
+
+  @override
+  Future<void> syncForegroundNotification({
+    required Profile? profile,
+    Iterable<Group> groups = const [],
+  }) async {}
+
+  @override
+  Future<void> syncForegroundNotificationForProxyChange({
+    required Profile? profile,
+    required String groupName,
+    required String proxyName,
+  }) async {}
+
+  @override
+  Future<void> syncGlobalModeEnabled({required bool enabled}) async {}
+
+  @override
+  Future<void> syncTileForProfileChange() async {}
+
+  @override
+  Future<void> syncTileMode(Mode mode) async {}
+
+  @override
+  Future<void> updateExcludeFromRecents({required bool hidden}) async {}
+}
+
+class DesktopAppUpdateService implements ProductUpdateService {
+  const DesktopAppUpdateService();
+
+  @override
+  Future<void> autoCheck({
+    required bool enabled,
+    required bool includePrerelease,
+    required String skippedTagName,
+    SkipAppUpdateRelease? onSkipRelease,
+  }) async {
+    // Startup checks must not fail the desktop shell; the manual path reports
+    // the missing installer explicitly.
+  }
+
+  @override
+  Future<void> manualCheck({
+    required AsyncTaskRunner runTask,
+    required bool includePrerelease,
+    required String skippedTagName,
+    SkipAppUpdateRelease? onSkipRelease,
+    String? loadingTitle,
+  }) =>
+      Future.error(
+        UnsupportedError(
+          desktopCapabilityMessage(DesktopCapability.updateInstallation),
+        ),
+      );
+}

--- a/lib/product/platform/desktop_security_policy.dart
+++ b/lib/product/platform/desktop_security_policy.dart
@@ -1,0 +1,34 @@
+import 'package:flclashx/models/models.dart';
+
+import '../compile/runtime_plan.dart';
+import '../security/security_policy.dart';
+
+/// Desktop has no Android socket exposure policy. It preserves the compiled
+/// profile unchanged until desktop runtime policy is introduced.
+class DesktopSecurityPolicy implements SecurityPolicy {
+  const DesktopSecurityPolicy();
+
+  @override
+  ClashConfig securePatchConfig({
+    required ClashConfig patchConfig,
+    required SecurityPolicyContext context,
+  }) =>
+      patchConfig;
+
+  @override
+  UpdateParams secureRuntimeUpdate({
+    required UpdateParams updateParams,
+    required SecurityPolicyContext context,
+  }) =>
+      updateParams;
+
+  @override
+  SecuredProfilePatch secureProfile({
+    required CompiledProfilePatch compiledProfile,
+    required SecurityPolicyContext context,
+  }) =>
+      SecuredProfilePatch(
+        patchConfig: compiledProfile.patchConfig,
+        metadata: compiledProfile.metadata,
+      );
+}

--- a/lib/product/platform/platform_profile.dart
+++ b/lib/product/platform/platform_profile.dart
@@ -2,45 +2,97 @@ import 'dart:io';
 
 import 'package:flclashx/enum/enum.dart';
 
-enum ProductPlatformKind { android, unsupported }
+enum ProductPlatformKind { android, linux, windows, macos, unsupported }
 
+/// The supported product hosts. This is intentionally independent from Flutter
+/// target-platform heuristics so composition has one deterministic input.
 class ProductPlatformProfile {
   const ProductPlatformProfile._({
     required this.kind,
     required this.hostPlatform,
+    required this.operatingSystem,
     required this.supported,
     required this.preferCompactNavigation,
   });
 
-  factory ProductPlatformProfile.current() {
-    if (Platform.isAndroid) {
-      return const ProductPlatformProfile._(
-        kind: ProductPlatformKind.android,
-        hostPlatform: SupportPlatform.Android,
-        supported: true,
-        preferCompactNavigation: true,
-      );
-    }
+  factory ProductPlatformProfile.current() =>
+      ProductPlatformProfile.fromOperatingSystem(Platform.operatingSystem);
 
-    return ProductPlatformProfile._(
-      kind: ProductPlatformKind.unsupported,
-      hostPlatform: SupportPlatform.currentPlatform,
-      supported: false,
-      preferCompactNavigation: true,
-    );
-  }
+  factory ProductPlatformProfile.fromOperatingSystem(String operatingSystem) =>
+      switch (operatingSystem.toLowerCase()) {
+        'android' => const ProductPlatformProfile._(
+            kind: ProductPlatformKind.android,
+            hostPlatform: SupportPlatform.Android,
+            operatingSystem: 'android',
+            supported: true,
+            preferCompactNavigation: true,
+          ),
+        'linux' => const ProductPlatformProfile._(
+            kind: ProductPlatformKind.linux,
+            hostPlatform: SupportPlatform.Linux,
+            operatingSystem: 'linux',
+            supported: true,
+            preferCompactNavigation: false,
+          ),
+        'windows' => const ProductPlatformProfile._(
+            kind: ProductPlatformKind.windows,
+            hostPlatform: SupportPlatform.Windows,
+            operatingSystem: 'windows',
+            supported: true,
+            preferCompactNavigation: false,
+          ),
+        'macos' => const ProductPlatformProfile._(
+            kind: ProductPlatformKind.macos,
+            hostPlatform: SupportPlatform.MacOS,
+            operatingSystem: 'macos',
+            supported: true,
+            preferCompactNavigation: false,
+          ),
+        _ => ProductPlatformProfile._(
+            kind: ProductPlatformKind.unsupported,
+            hostPlatform: _hostPlatformOrAndroid(),
+            operatingSystem: operatingSystem,
+            supported: false,
+            preferCompactNavigation: true,
+          ),
+      };
 
   final ProductPlatformKind kind;
   final SupportPlatform hostPlatform;
+  final String operatingSystem;
   final bool supported;
   final bool preferCompactNavigation;
 
   bool get isAndroid => kind == ProductPlatformKind.android;
 
+  bool get isDesktop => switch (kind) {
+        ProductPlatformKind.linux ||
+        ProductPlatformKind.windows ||
+        ProductPlatformKind.macos =>
+          true,
+        _ => false,
+      };
+
   bool get isUnsupported => kind == ProductPlatformKind.unsupported;
 
   NavigationItemMode resolveNavigationMode(double viewWidth) =>
-      NavigationItemMode.mobile;
+      preferCompactNavigation
+          ? NavigationItemMode.mobile
+          : NavigationItemMode.desktop;
+
+  String get unsupportedMessage =>
+      'FlClashM does not support `$operatingSystem`. '
+      'Supported platforms: Android, Linux, Windows, macOS.';
+
+  static SupportPlatform _hostPlatformOrAndroid() {
+    try {
+      return SupportPlatform.currentPlatform;
+    } catch (_) {
+      // SupportPlatform predates web/other hosts. The value is only kept for
+      // legacy UI APIs; unsupported hosts fail before the application starts.
+      return SupportPlatform.Android;
+    }
+  }
 }
 
 final productPlatform = ProductPlatformProfile.current();

--- a/lib/product/platform/product_install_layout.dart
+++ b/lib/product/platform/product_install_layout.dart
@@ -1,0 +1,56 @@
+import 'package:path/path.dart' as path;
+
+/// Names consumed by both artifact assembly and the runtime supervisor.
+///
+/// Platform-specific packaging may choose the root, but never the structure
+/// below it: `<root>/runtimes/<target>/<architecture>/<artifact>`.
+class ProductInstallLayout {
+  const ProductInstallLayout._();
+
+  static const desktopApplicationId = 'app.flclashm.client';
+  static const desktopHelperName = '$desktopApplicationId.helper';
+  static const runtimeDirectoryName = 'runtimes';
+
+  static const mihomoArtifact = 'mihomo';
+  static const helperArtifact = 'helper';
+  static const naiveproxyArtifact = 'naiveproxy';
+  static const olcrtcArtifact = 'olcrtc';
+  static const byedpiArtifact = 'byedpi';
+  static const stormdnsArtifact = 'stormdns';
+
+  static const artifacts = <String>[
+    mihomoArtifact,
+    helperArtifact,
+    naiveproxyArtifact,
+    olcrtcArtifact,
+    byedpiArtifact,
+    stormdnsArtifact,
+  ];
+
+  static String runtimeRoot({
+    required String installRoot,
+    required String target,
+    required String architecture,
+  }) =>
+      path.join(installRoot, runtimeDirectoryName, target, architecture);
+
+  static String artifactPath({
+    required String installRoot,
+    required String target,
+    required String architecture,
+    required String artifact,
+  }) {
+    if (!artifacts.contains(artifact)) {
+      throw ArgumentError.value(
+          artifact, 'artifact', 'Unknown runtime artifact');
+    }
+    return path.join(
+      runtimeRoot(
+        installRoot: installRoot,
+        target: target,
+        architecture: architecture,
+      ),
+      artifact,
+    );
+  }
+}

--- a/lib/product/platform/product_install_layout.dart
+++ b/lib/product/platform/product_install_layout.dart
@@ -12,7 +12,7 @@ class ProductInstallLayout {
   static const runtimeDirectoryName = 'runtimes';
 
   static const mihomoArtifact = 'mihomo';
-  static const helperArtifact = 'helper';
+  static const helperArtifact = desktopHelperName;
   static const naiveproxyArtifact = 'naiveproxy';
   static const olcrtcArtifact = 'olcrtc';
   static const byedpiArtifact = 'byedpi';

--- a/lib/product/platform/product_platform_composition.dart
+++ b/lib/product/platform/product_platform_composition.dart
@@ -1,3 +1,4 @@
+import '../../clash/core.dart';
 import '../../common/android.dart';
 import '../android/android_entrypoint.dart';
 import '../android/android_platform.dart';
@@ -10,11 +11,16 @@ import 'desktop_security_policy.dart';
 import 'platform_profile.dart';
 
 abstract interface class ProductPlatformBootstrap {
+  Future<bool> preloadMihomo();
+
   Future<void> initialize();
 }
 
 class AndroidPlatformBootstrap implements ProductPlatformBootstrap {
   const AndroidPlatformBootstrap();
+
+  @override
+  Future<bool> preloadMihomo() => clashCore.preload();
 
   @override
   Future<void> initialize() async {
@@ -25,6 +31,9 @@ class AndroidPlatformBootstrap implements ProductPlatformBootstrap {
 
 class DesktopPlatformBootstrap implements ProductPlatformBootstrap {
   const DesktopPlatformBootstrap();
+
+  @override
+  Future<bool> preloadMihomo() async => false;
 
   @override
   Future<void> initialize() async {}

--- a/lib/product/platform/product_platform_composition.dart
+++ b/lib/product/platform/product_platform_composition.dart
@@ -1,0 +1,101 @@
+import '../../common/android.dart';
+import '../android/android_entrypoint.dart';
+import '../android/android_platform.dart';
+import '../runtime/runtime_types.dart';
+import '../security/android_security_policy.dart';
+import '../security/security_policy.dart';
+import '../services/product_services.dart';
+import 'desktop_platform_services.dart';
+import 'desktop_security_policy.dart';
+import 'platform_profile.dart';
+
+abstract interface class ProductPlatformBootstrap {
+  Future<void> initialize();
+}
+
+class AndroidPlatformBootstrap implements ProductPlatformBootstrap {
+  const AndroidPlatformBootstrap();
+
+  @override
+  Future<void> initialize() async {
+    await android?.init();
+    await androidEntrypoint.init();
+  }
+}
+
+class DesktopPlatformBootstrap implements ProductPlatformBootstrap {
+  const DesktopPlatformBootstrap();
+
+  @override
+  Future<void> initialize() async {}
+}
+
+/// The only product composition root. New platforms provide their platform
+/// boundary objects here rather than letting desktop code reach Android bridges.
+class ProductPlatformComposition {
+  ProductPlatformComposition._({
+    required this.profile,
+    required this.services,
+    required this.securityPolicy,
+    required this.bootstrap,
+    required this.mihomoAvailability,
+  });
+
+  factory ProductPlatformComposition.forProfile(
+      ProductPlatformProfile profile) {
+    if (!profile.supported) {
+      throw UnsupportedError(profile.unsupportedMessage);
+    }
+
+    if (profile.isAndroid) {
+      return ProductPlatformComposition._(
+        profile: profile,
+        services: ProductServices(
+          accessControl: AccessControlService(
+            platform: androidPlatform.runtimeAccess,
+          ),
+          androidShell: AndroidShellService(
+            platform: androidPlatform.shell,
+            foregroundNotification: androidPlatform.foregroundNotification,
+          ),
+          appUpdate: AppUpdateService(platform: androidPlatform.updateBridge),
+        ),
+        securityPolicy: const AndroidSecurityPolicy(),
+        bootstrap: const AndroidPlatformBootstrap(),
+        mihomoAvailability: const RuntimeAvailability.supported(
+          updatePath:
+              'Bundled Android core is built by setup.dart into libclash/android.',
+          rollbackPath:
+              'Fallback stays on the bundled mihomo path and current cold-start snapshot.',
+        ),
+      );
+    }
+
+    return ProductPlatformComposition._(
+      profile: profile,
+      services: ProductServices(
+        accessControl: const AccessControlService(
+          platform: DesktopRuntimeAccessPolicy(),
+        ),
+        androidShell: const DesktopShellService(),
+        appUpdate: const DesktopAppUpdateService(),
+      ),
+      securityPolicy: const DesktopSecurityPolicy(),
+      bootstrap: const DesktopPlatformBootstrap(),
+      mihomoAvailability: RuntimeAvailability.unsupported(
+        reason: desktopCapabilityMessage(DesktopCapability.tun),
+        updatePath: 'Desktop runtime integration has not been released yet.',
+        rollbackPath: 'Keep using the Android runtime until desktop TUN ships.',
+      ),
+    );
+  }
+
+  final ProductPlatformProfile profile;
+  final ProductServices services;
+  final SecurityPolicy securityPolicy;
+  final ProductPlatformBootstrap bootstrap;
+  final RuntimeAvailability mihomoAvailability;
+}
+
+final productPlatformComposition =
+    ProductPlatformComposition.forProfile(productPlatform);

--- a/lib/product/runtime/engine_manager.dart
+++ b/lib/product/runtime/engine_manager.dart
@@ -113,7 +113,6 @@ class EngineManager {
     required BuildCoreStateCallback buildCoreState,
     required BuildInitParamsCallback buildInitParams,
   })  : _runtimeRegistry = runtimeRegistry,
-        _activeRuntime = runtimeRegistry.resolveSelection(),
         _loadCurrentRawProfile = loadCurrentRawProfile,
         _compileProfilePatch = compileProfilePatch,
         _enforceSecurityPolicy = enforceSecurityPolicy,
@@ -124,7 +123,7 @@ class EngineManager {
         _buildInitParams = buildInitParams;
 
   final RuntimeRegistry _runtimeRegistry;
-  ResolvedRuntimeSelection _activeRuntime;
+  ResolvedRuntimeSelection? _activeRuntime;
   final LoadCurrentRawProfileCallback _loadCurrentRawProfile;
   final CompileProfilePatchCallback _compileProfilePatch;
   final EnforceSecurityPolicyCallback _enforceSecurityPolicy;
@@ -142,12 +141,15 @@ class EngineManager {
   _CompiledRuntimePlan? _pendingCompiledRuntimePlan;
   Future<void> _coldStartPersistChain = Future<void>.value();
 
-  EngineAdapter get _adapter => _activeRuntime.engine.adapter;
+  ResolvedRuntimeSelection get _resolvedRuntime =>
+      _activeRuntime ??= _runtimeRegistry.resolveSelection();
+
+  EngineAdapter get _adapter => _resolvedRuntime.engine.adapter;
 
   RuntimeId get activeEngineId =>
-      _activeRuntime.engine.registration.descriptor.id;
+      _resolvedRuntime.engine.registration.descriptor.id;
 
-  RuntimeSelection get activeRuntimeSelection => _activeRuntime.selection;
+  RuntimeSelection get activeRuntimeSelection => _resolvedRuntime.selection;
 
   DateTime? get startTime => _startTime;
 
@@ -813,12 +815,13 @@ class EngineManager {
 
   ResolvedRuntimeSelection _resolveRuntimeSelection(
       RuntimeSelection selection) {
-    if (_activeRuntime.selection == selection) {
-      return _activeRuntime;
+    final activeRuntime = _activeRuntime;
+    if (activeRuntime?.selection == selection) {
+      return activeRuntime!;
     }
     if (isStarted) {
       throw UnsupportedRuntimeSelectionException(
-        'Runtime switch from ${_activeRuntime.selection.engine.label} '
+        'Runtime switch from ${activeRuntime!.selection.engine.label} '
         'to ${selection.engine.label} requires a full stop/restart boundary.',
       );
     }

--- a/lib/product/runtime/runtime_registry.dart
+++ b/lib/product/runtime/runtime_registry.dart
@@ -67,7 +67,7 @@ class RuntimeRegistry {
     required ReadAccessControlCallback readAccessControl,
     AccessControl? Function()? readProfileAccessControl,
     RuntimeHealthProbe? runtimeHealthProbe,
-    RuntimeAvailability? mihomoAvailability,
+    required RuntimeAvailability mihomoAvailability,
   }) =>
       RuntimeRegistry(
         defaultSelection: const RuntimeSelection.mihomo(),
@@ -81,13 +81,7 @@ class RuntimeRegistry {
                 RuntimeCapability.coldStartPersistence,
               },
             ),
-            availability: mihomoAvailability ??
-                const RuntimeAvailability.supported(
-                  updatePath:
-                      'Bundled Android core is built by setup.dart into libclash/android.',
-                  rollbackPath:
-                      'Fallback stays on the bundled mihomo path and current cold-start snapshot.',
-                ),
+            availability: mihomoAvailability,
             adapterFactory: () => _buildMihomoEngineAdapter(
               readAccessControl,
               readProfileAccessControl,

--- a/lib/product/runtime/runtime_registry.dart
+++ b/lib/product/runtime/runtime_registry.dart
@@ -67,6 +67,7 @@ class RuntimeRegistry {
     required ReadAccessControlCallback readAccessControl,
     AccessControl? Function()? readProfileAccessControl,
     RuntimeHealthProbe? runtimeHealthProbe,
+    RuntimeAvailability? mihomoAvailability,
   }) =>
       RuntimeRegistry(
         defaultSelection: const RuntimeSelection.mihomo(),
@@ -80,12 +81,13 @@ class RuntimeRegistry {
                 RuntimeCapability.coldStartPersistence,
               },
             ),
-            availability: const RuntimeAvailability.supported(
-              updatePath:
-                  'Bundled Android core is built by setup.dart into libclash/android.',
-              rollbackPath:
-                  'Fallback stays on the bundled mihomo path and current cold-start snapshot.',
-            ),
+            availability: mihomoAvailability ??
+                const RuntimeAvailability.supported(
+                  updatePath:
+                      'Bundled Android core is built by setup.dart into libclash/android.',
+                  rollbackPath:
+                      'Fallback stays on the bundled mihomo path and current cold-start snapshot.',
+                ),
             adapterFactory: () => _buildMihomoEngineAdapter(
               readAccessControl,
               readProfileAccessControl,

--- a/lib/product/services/android_shell_service.dart
+++ b/lib/product/services/android_shell_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: annotate_overrides
+
 import 'dart:async';
 
 import '../../common/common.dart';
@@ -5,8 +7,9 @@ import '../../enum/enum.dart';
 import '../../models/models.dart';
 import '../android/android_foreground_notification_policy.dart';
 import '../android/android_shell_bridge.dart';
+import 'product_shell_service.dart';
 
-class AndroidShellService {
+class AndroidShellService implements ProductShellService {
   AndroidShellService({
     this.platform = const AndroidShellBridge(),
     this.foregroundNotification = const AndroidForegroundNotificationPolicy(),

--- a/lib/product/services/app_update_service.dart
+++ b/lib/product/services/app_update_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: annotate_overrides
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -5,20 +7,14 @@ import 'package:path/path.dart' as path;
 import '../../common/common.dart';
 import '../android/android_update_bridge.dart';
 import 'app_update_release.dart';
-
-typedef AsyncTaskRunner = Future<T?> Function<T>(
-  Future<T> Function() task, {
-  String? title,
-});
+import 'product_update_service.dart';
 
 enum AppUpdateCheckTrigger {
   automatic,
   manual,
 }
 
-typedef SkipAppUpdateRelease = Future<void> Function(String tagName);
-
-class AppUpdateService {
+class AppUpdateService implements ProductUpdateService {
   const AppUpdateService({
     this.platform = const AndroidUpdateBridge(),
   });

--- a/lib/product/services/product_services.dart
+++ b/lib/product/services/product_services.dart
@@ -1,6 +1,9 @@
+import '../platform/product_platform_composition.dart';
 import 'access_control_service.dart';
 import 'android_shell_service.dart';
 import 'app_update_service.dart';
+import 'product_shell_service.dart';
+import 'product_update_service.dart';
 
 export '../widgets/access_control_notice.dart';
 export 'access_control_service.dart';
@@ -11,13 +14,17 @@ export 'product_contributors.dart';
 class ProductServices {
   ProductServices({
     this.accessControl = const AccessControlService(),
-    AndroidShellService? androidShell,
-    this.appUpdate = const AppUpdateService(),
-  }) : androidShell = androidShell ?? AndroidShellService();
+    ProductShellService? androidShell,
+    ProductUpdateService? appUpdate,
+  })  : androidShell = androidShell ?? AndroidShellService(),
+        appUpdate = appUpdate ?? const AppUpdateService();
 
   final AccessControlService accessControl;
-  final AndroidShellService androidShell;
-  final AppUpdateService appUpdate;
+
+  /// Kept as `androidShell` for stable base touchpoints. Its implementation is
+  /// selected only by [ProductPlatformComposition].
+  final ProductShellService androidShell;
+  final ProductUpdateService appUpdate;
 }
 
-final productServices = ProductServices();
+final productServices = productPlatformComposition.services;

--- a/lib/product/services/product_shell_service.dart
+++ b/lib/product/services/product_shell_service.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import '../../enum/enum.dart';
+import '../../models/models.dart';
+
+/// Product-facing shell contract. Android owns the platform integrations;
+/// desktop implementations deliberately do not bridge to Android channels.
+abstract interface class ProductShellService {
+  void bindTileCommands({
+    FutureOr<void> Function()? onStart,
+    FutureOr<void> Function()? onStop,
+    FutureOr<void> Function(String mode)? onChangeMode,
+  });
+
+  void installExitHook(FutureOr<void> Function() onExit);
+
+  Future<void> signalServiceReady();
+  Future<void> initShortcuts();
+  Future<void> moveTaskToBack();
+  Future<void> updateExcludeFromRecents({required bool hidden});
+  Future<void> syncTileForProfileChange();
+  Future<void> syncTileMode(Mode mode);
+  Future<void> syncGlobalModeEnabled({required bool enabled});
+  Future<void> showTip(String message);
+  Future<void> pushForegroundNotificationTitle(String title);
+
+  String buildForegroundNotificationTitle({
+    required Profile? profile,
+    Iterable<Group> groups,
+  });
+
+  Future<void> syncForegroundNotification({
+    required Profile? profile,
+    Iterable<Group> groups,
+  });
+
+  Future<void> syncForegroundNotificationForProxyChange({
+    required Profile? profile,
+    required String groupName,
+    required String proxyName,
+  });
+
+  Future<void> notifyStartRequested();
+  Future<void> notifyStopRequested();
+  Future<void> notifyNoProfileSelected();
+  Future<void> notifyRuntimeNotReady();
+  Future<void> notifyVpnStartFailed();
+  Future<void> notifyStartError(Object error);
+}

--- a/lib/product/services/product_update_service.dart
+++ b/lib/product/services/product_update_service.dart
@@ -1,0 +1,25 @@
+typedef AsyncTaskRunner = Future<T?> Function<T>(
+  Future<T> Function() task, {
+  String? title,
+});
+
+typedef SkipAppUpdateRelease = Future<void> Function(String tagName);
+
+/// Product-facing updater contract. A platform must explicitly provide an
+/// installer instead of silently treating an unsupported handoff as success.
+abstract interface class ProductUpdateService {
+  Future<void> autoCheck({
+    required bool enabled,
+    required bool includePrerelease,
+    required String skippedTagName,
+    SkipAppUpdateRelease? onSkipRelease,
+  });
+
+  Future<void> manualCheck({
+    required AsyncTaskRunner runTask,
+    required bool includePrerelease,
+    required String skippedTagName,
+    SkipAppUpdateRelease? onSkipRelease,
+    String? loadingTitle,
+  });
+}

--- a/lib/product/services/runtime_access_platform.dart
+++ b/lib/product/services/runtime_access_platform.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+import '../../enum/enum.dart';
+import '../../models/models.dart';
+import '../runtime/engine_manager.dart';
+
+@immutable
+class ProfileAccessSnapshot {
+  const ProfileAccessSnapshot.available(this.accessControl) : available = true;
+
+  const ProfileAccessSnapshot.unavailable()
+      : available = false,
+        accessControl = null;
+
+  final bool available;
+  final AccessControl? accessControl;
+}
+
+/// Platform boundary for TUN and Android package inventory.
+abstract interface class RuntimeAccessPlatformBridge {
+  bool get isAndroid;
+
+  Future<List<Package>> readPackages();
+  Future<ImageProvider?> readPackageIcon(String packageName);
+
+  String mergeVpnOptions(
+    String optionsJson, {
+    required AccessControl accessControl,
+  });
+
+  Future<bool> startVpn({required AccessControl accessControl});
+  Future<void> stopVpn();
+  Future<ProfileAccessSnapshot> readAppliedProfileAccess();
+
+  Future<ResolvedTunAccess> resolveTunAccess({
+    required bool requestedTunEnable,
+    required bool realTunEnable,
+    required Future<void> Function() onAuthorizeRestart,
+    required ValueChanged<bool> onResolvedTunEnable,
+    Future<AuthorizeCode> Function()? authorizeCore,
+  });
+}

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -26,6 +26,7 @@ import 'core_version.dart';
 import 'models/models.dart';
 import 'plugins/app.dart';
 import 'product/compile/product_compile.dart';
+import 'product/platform/product_platform_composition.dart';
 import 'product/runtime/product_runtime.dart';
 import 'product/security/product_security.dart';
 
@@ -89,6 +90,7 @@ class GlobalState {
       readAccessControl: () => config.vpnProps.accessControl,
       readProfileAccessControl: () => activeProfileAccessControl,
       runtimeHealthProbe: const AppRuntimeHealthProbe(),
+      mihomoAvailability: productPlatformComposition.mihomoAvailability,
     );
     engineManager = EngineManager(
       runtimeRegistry: runtimeRegistry,

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "FlClashM")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.makriq.flclash")
+set(APPLICATION_ID "app.flclashm.client")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.
@@ -107,6 +107,15 @@ install(CODE "
 
 set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
 set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+  set(RUNTIME_ARCHITECTURE "x86_64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+  set(RUNTIME_ARCHITECTURE "arm64")
+else()
+  message(FATAL_ERROR "Unsupported Linux runtime architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+set(INSTALL_RUNTIME_DIR
+  "${CMAKE_INSTALL_PREFIX}/runtimes/linux/${RUNTIME_ARCHITECTURE}")
 
 install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)
@@ -117,10 +126,10 @@ install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}
 install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)
 
-# libclash.so
+# Desktop runtime artifacts use the ProductInstallLayout contract.
 set(CLASH_DIR "../libclash/linux")
-install(PROGRAMS "${CLASH_DIR}/FlClashCore" DESTINATION "${BUILD_BUNDLE_DIR}"
-  COMPONENT Runtime)
+install(PROGRAMS "${CLASH_DIR}/FlClashCore" DESTINATION "${INSTALL_RUNTIME_DIR}"
+  RENAME "mihomo" COMPONENT Runtime)
 
 foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
   install(FILES "${bundled_library}"

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		5377B2253E1C5AB4D9D56A31 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72CBDF47BB69EDEFE644C48D /* Pods_RunnerTests.framework */; };
 		7AC6855B2B8AF836004C123B /* BuildFile in Bundle Framework */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		CDD319C761C7664F6008596B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4121E8CCDC7DC35194714CDE /* Pods_Runner.framework */; };
-		F50091052CF74B7700D43AEA /* FlClashCore in CopyFiles */ = {isa = PBXBuildFile; fileRef = F50091042CF74B7700D43AEA /* FlClashCore */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F5AA39AF2DA1D9FB00F5C816 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = F5AA39AE2DA1D9FB00F5C816 /* LaunchAtLogin */; };
 /* End PBXBuildFile section */
 
@@ -62,16 +61,6 @@
 				7AC6855B2B8AF836004C123B /* BuildFile in Bundle Framework */,
 			);
 			name = "Bundle Framework";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F50091032CF74B6400D43AEA /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 6;
-			files = (
-				F50091052CF74B7700D43AEA /* FlClashCore in CopyFiles */,
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F5FAC0AA2CEDC4DA000CF079 /* CopyFiles */ = {
@@ -122,7 +111,6 @@
 		8F1D6D6423063FA738863205 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		CA9CA9C2D0B5E93A91F45924 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
-		F50091042CF74B7700D43AEA /* FlClashCore */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = FlClashCore; path = ../libclash/macos/FlClashCore; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -168,7 +156,6 @@
 		33CC10E42044A3C60003C045 = {
 			isa = PBXGroup;
 			children = (
-				F50091042CF74B7700D43AEA /* FlClashCore */,
 				33FAB671232836740065AC1E /* Runner */,
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				331C80D6294CF71000263BE5 /* RunnerTests */,
@@ -281,7 +268,7 @@
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				1522C6AC211009D2A7DFAD40 /* [CP] Embed Pods Frameworks */,
 				F5FAC0AE2CEDC891000CF079 /* CopyFiles */,
-				F50091032CF74B6400D43AEA /* CopyFiles */,
+				F50091062CF74B7700D43AEA /* Install runtime layout */,
 			);
 			buildRules = (
 			);
@@ -366,6 +353,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		F50091062CF74B7700D43AEA /* Install runtime layout */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(PROJECT_DIR)/../libclash/macos/FlClashCore",
+			);
+			name = "Install runtime layout";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Contents/runtimes/macos/$(CURRENT_ARCH)/mihomo",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "runtime_dir=\"$TARGET_BUILD_DIR/$WRAPPER_NAME/Contents/runtimes/macos/$CURRENT_ARCH\"\nmkdir -p \"$runtime_dir\"\ncp \"$PROJECT_DIR/../libclash/macos/FlClashCore\" \"$runtime_dir/mihomo\"\nchmod +x \"$runtime_dir/mihomo\"\n";
+		};
 		1522C6AC211009D2A7DFAD40 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -19,9 +19,6 @@ class AppDelegate: FlutterAppDelegate {
     override func applicationDidFinishLaunching(_ aNotification: Notification) {
         NSLog("AppDelegate: applicationDidFinishLaunching called")
         
-        setupCoreInApplicationSupport()
-        
-        
         guard let mainController = mainFlutterWindow?.contentViewController as? FlutterViewController else {
             NSLog("ERROR: Could not get FlutterViewController from mainFlutterWindow")
             return
@@ -99,94 +96,6 @@ class AppDelegate: FlutterAppDelegate {
         NSLog("Zashboard channel set up successfully")
     }
 
-    func setupCoreInApplicationSupport() {
-        guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            print("ERROR: Could not get Application Support directory")
-            return
-        }
-        
-        let bundleURL = Bundle.main.bundleURL
-        let bundleCorePath = bundleURL.appendingPathComponent("Contents/MacOS/FlClashCore")
-        let appSupportCorePath = appSupportURL.appendingPathComponent("com.follow.clash/cores/FlClashCore")
-        let appSupportDir = appSupportCorePath.deletingLastPathComponent()
-        
-        do {
-            try FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
-            print("Directory created: \(appSupportDir.path)")
-            
-            let coreExists = FileManager.default.fileExists(atPath: appSupportCorePath.path)
-            let needsUpdate = !coreExists || shouldUpdateCore(bundlePath: bundleCorePath.path, appSupportPath: appSupportCorePath.path)
-            
-            if needsUpdate {
-                try? FileManager.default.removeItem(at: appSupportCorePath)
-                
-                try FileManager.default.copyItem(at: bundleCorePath, to: appSupportCorePath)
-                
-                if setCorePermissions(corePath: appSupportCorePath.path) {
-                    print("FlClashCore updated to: \(appSupportCorePath.path)")
-                }
-            } else {
-                let attrs = try? FileManager.default.attributesOfItem(atPath: appSupportCorePath.path)
-                if let posixPerms = attrs?[.posixPermissions] as? NSNumber {
-                    // Check if setuid bit is set (04000 in octal)
-                    if (posixPerms.uint16Value & 0o4000) == 0 {
-                        print("Permissions not set, setting them now...")
-                        let _ = setCorePermissions(corePath: appSupportCorePath.path)
-                    } else {
-                        print("FlClashCore already up-to-date with correct permissions")
-                    }
-                }
-            }
-        } catch {
-            print("Failed to setup core: \(error)")
-        }
-    }
-    
-    func setCorePermissions(corePath: String) -> Bool {
-        let escaped = corePath.replacingOccurrences(of: "'", with: "'\\''")
-        let script = """
-        do shell script "chown root:admin '\(escaped)' && chmod +sx '\(escaped)'" with administrator privileges
-        """
-        
-        var error: NSDictionary?
-        if let scriptObject = NSAppleScript(source: script) {
-            scriptObject.executeAndReturnError(&error)
-            if let error = error {
-                if let errorCode = error["NSAppleScriptErrorNumber"] as? Int, errorCode == -128 {
-                    print("User cancelled password prompt")
-                    showPermissionRequiredAlert()
-                    NSApplication.shared.terminate(nil)
-                    return false
-                }
-                print("Failed to set permissions: \(error)")
-                return false
-            } else {
-                print("Permissions set successfully for: \(corePath)")
-                return true
-            }
-        }
-        return false
-    }
-    
-    func showPermissionRequiredAlert() {
-        let alert = NSAlert()
-        alert.messageText = "Administrator Access Required"
-        alert.informativeText = "FlClashM requires administrator privileges to set up the network core. The application cannot run without these permissions.\n\nPlease restart the application and grant administrator access when prompted."
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Quit")
-        alert.runModal()
-    }
-    
-    func shouldUpdateCore(bundlePath: String, appSupportPath: String) -> Bool {
-        guard let bundleAttrs = try? FileManager.default.attributesOfItem(atPath: bundlePath),
-              let appSupportAttrs = try? FileManager.default.attributesOfItem(atPath: appSupportPath),
-              let bundleDate = bundleAttrs[.modificationDate] as? Date,
-              let appSupportDate = appSupportAttrs[.modificationDate] as? Date else {
-            return true
-        }
-        return bundleDate > appSupportDate
-    }
-    
     override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return false
     }

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = FlClashM
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.follow.clash
+PRODUCT_BUNDLE_IDENTIFIER = app.flclashm.client
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2023 com.follow. All rights reserved.

--- a/test/product/platform/product_platform_composition_test.dart
+++ b/test/product/platform/product_platform_composition_test.dart
@@ -11,6 +11,7 @@ import 'package:flclashx/product/runtime/runtime_types.dart';
 import 'package:flclashx/product/security/android_security_policy.dart';
 import 'package:flclashx/product/services/android_shell_service.dart';
 import 'package:flclashx/product/services/app_update_service.dart';
+import 'package:flclashx/state.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -74,12 +75,18 @@ void main() {
       expect(composition.services.androidShell, isA<DesktopShellService>());
       expect(composition.services.appUpdate, isA<DesktopAppUpdateService>());
       expect(composition.mihomoAvailability.isSupported, isFalse);
+      expect(await composition.bootstrap.preloadMihomo(), isFalse);
       final runtimeRegistry = RuntimeRegistry.flClashM(
         readAccessControl: () => const AccessControl(),
         mihomoAvailability: composition.mihomoAvailability,
       );
       expect(
         runtimeRegistry.resolveSelection,
+        throwsA(isA<UnsupportedRuntimeSelectionException>()),
+      );
+      expect(globalState.engineManager.isStarted, isFalse);
+      expect(
+        globalState.runtimeRegistry.resolveSelection,
         throwsA(isA<UnsupportedRuntimeSelectionException>()),
       );
       await expectLater(
@@ -114,6 +121,37 @@ void main() {
         artifact: ProductInstallLayout.stormdnsArtifact,
       ),
       '/opt/flclashm/runtimes/linux/x86_64/stormdns',
+    );
+  });
+
+  test('uses the stable desktop ID and runtime layout in every build target',
+      () async {
+    final sources = await Future.wait([
+      File('lib/common/path.dart').readAsString(),
+      File('linux/CMakeLists.txt').readAsString(),
+      File('windows/CMakeLists.txt').readAsString(),
+      File('macos/Runner/Configs/AppInfo.xcconfig').readAsString(),
+      File('macos/Runner.xcodeproj/project.pbxproj').readAsString(),
+    ]);
+    final runtimeResolver = sources[0];
+    final linux = sources[1];
+    final windows = sources[2];
+    final macosConfig = sources[3];
+    final macosProject = sources[4];
+
+    expect(runtimeResolver, contains('ProductInstallLayout.mihomoArtifact'));
+    expect(runtimeResolver, contains('ProductInstallLayout.helperArtifact'));
+    expect(linux, contains('set(APPLICATION_ID "app.flclashm.client")'));
+    expect(linux, contains(r'/runtimes/linux/${RUNTIME_ARCHITECTURE}'));
+    expect(linux, contains('RENAME "mihomo"'));
+    expect(windows, contains(r'/runtimes/windows/${RUNTIME_ARCHITECTURE}'));
+    expect(windows, contains('RENAME "mihomo.exe"'));
+    expect(windows, contains('RENAME "app.flclashm.client.helper.exe"'));
+    expect(macosConfig,
+        contains('PRODUCT_BUNDLE_IDENTIFIER = app.flclashm.client'));
+    expect(
+      macosProject,
+      contains(r'Contents/runtimes/macos/$(CURRENT_ARCH)/mihomo'),
     );
   });
 }

--- a/test/product/platform/product_platform_composition_test.dart
+++ b/test/product/platform/product_platform_composition_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flclashx/models/models.dart';
+import 'package:flclashx/product/android/android_runtime_access_policy.dart';
+import 'package:flclashx/product/platform/desktop_platform_services.dart';
+import 'package:flclashx/product/platform/platform_profile.dart';
+import 'package:flclashx/product/platform/product_install_layout.dart';
+import 'package:flclashx/product/platform/product_platform_composition.dart';
+import 'package:flclashx/product/runtime/runtime_registry.dart';
+import 'package:flclashx/product/runtime/runtime_types.dart';
+import 'package:flclashx/product/security/android_security_policy.dart';
+import 'package:flclashx/product/services/android_shell_service.dart';
+import 'package:flclashx/product/services/app_update_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProductPlatformProfile', () {
+    test('recognizes every supported product host', () {
+      expect(
+        ProductPlatformProfile.fromOperatingSystem('android').kind,
+        ProductPlatformKind.android,
+      );
+      expect(
+        ProductPlatformProfile.fromOperatingSystem('linux').kind,
+        ProductPlatformKind.linux,
+      );
+      expect(
+        ProductPlatformProfile.fromOperatingSystem('windows').kind,
+        ProductPlatformKind.windows,
+      );
+      expect(
+        ProductPlatformProfile.fromOperatingSystem('macos').kind,
+        ProductPlatformKind.macos,
+      );
+    });
+
+    test('rejects an unsupported host with a useful error', () {
+      final profile = ProductPlatformProfile.fromOperatingSystem('freebsd');
+
+      expect(profile.supported, isFalse);
+      expect(profile.unsupportedMessage, contains('freebsd'));
+      expect(
+        () => ProductPlatformComposition.forProfile(profile),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('ProductPlatformComposition', () {
+    test('preserves Android service and security implementations', () {
+      final composition = ProductPlatformComposition.forProfile(
+        ProductPlatformProfile.fromOperatingSystem('android'),
+      );
+
+      expect(composition.securityPolicy, isA<AndroidSecurityPolicy>());
+      expect(
+        composition.services.accessControl.platform,
+        isA<AndroidRuntimeAccessPolicy>(),
+      );
+      expect(composition.services.androidShell, isA<AndroidShellService>());
+      expect(composition.services.appUpdate, isA<AppUpdateService>());
+      expect(composition.mihomoAvailability.isSupported, isTrue);
+    });
+
+    test('uses channel-free desktop stubs and rejects TUN', () async {
+      final composition = ProductPlatformComposition.forProfile(
+        ProductPlatformProfile.fromOperatingSystem('linux'),
+      );
+
+      expect(
+        composition.services.accessControl.platform,
+        isA<DesktopRuntimeAccessPolicy>(),
+      );
+      expect(composition.services.androidShell, isA<DesktopShellService>());
+      expect(composition.services.appUpdate, isA<DesktopAppUpdateService>());
+      expect(composition.mihomoAvailability.isSupported, isFalse);
+      final runtimeRegistry = RuntimeRegistry.flClashM(
+        readAccessControl: () => const AccessControl(),
+        mihomoAvailability: composition.mihomoAvailability,
+      );
+      expect(
+        runtimeRegistry.resolveSelection,
+        throwsA(isA<UnsupportedRuntimeSelectionException>()),
+      );
+      await expectLater(
+        composition.services.accessControl.startVpn(
+          accessControl: const AccessControl(enable: true),
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('desktop source never imports Android channels', () async {
+      final source = await File(
+        'lib/product/platform/desktop_platform_services.dart',
+      ).readAsString();
+
+      expect(source, isNot(contains('MethodChannel')));
+      expect(source, isNot(contains("../android/")));
+    });
+  });
+
+  test('keeps one stable runtime artifact layout', () {
+    expect(ProductInstallLayout.desktopApplicationId, 'app.flclashm.client');
+    expect(
+      ProductInstallLayout.desktopHelperName,
+      'app.flclashm.client.helper',
+    );
+    expect(
+      ProductInstallLayout.artifactPath(
+        installRoot: '/opt/flclashm',
+        target: 'linux',
+        architecture: 'x86_64',
+        artifact: ProductInstallLayout.stormdnsArtifact,
+      ),
+      '/opt/flclashm/runtimes/linux/x86_64/stormdns',
+    );
+  });
+}

--- a/test/product/runtime/runtime_registry_test.dart
+++ b/test/product/runtime/runtime_registry_test.dart
@@ -7,6 +7,10 @@ void main() {
   group('RuntimeRegistry', () {
     final registry = RuntimeRegistry.flClashM(
       readAccessControl: () => const AccessControl(),
+      mihomoAvailability: const RuntimeAvailability.supported(
+        updatePath: 'bundled',
+        rollbackPath: 'bundled',
+      ),
     );
 
     test('resolves bundled mihomo by default', () {

--- a/tool/product_touchpoints.json
+++ b/tool/product_touchpoints.json
@@ -33,6 +33,14 @@
       ]
     },
     {
+      "path": "lib/common/path.dart",
+      "boundary": "desktop-runtime-layout",
+      "reason": "The base path facade resolves desktop runtime artifacts only through the product-owned stable install layout.",
+      "targets": [
+        "lib/product/platform/product_install_layout.dart"
+      ]
+    },
+    {
       "path": "lib/common/system.dart",
       "boundary": "platform-shell-bootstrap",
       "reason": "System helpers stay a thin base delegate for Android task-back behavior.",
@@ -104,9 +112,10 @@
     {
       "path": "lib/state.dart",
       "boundary": "global-runtime-wiring",
-      "reason": "GlobalState may wire compile, security, runtime registry and engine manager callbacks without embedding product policy locally.",
+      "reason": "GlobalState receives compile, security and runtime availability only from the product composition without embedding platform policy locally.",
       "targets": [
         "lib/product/compile/product_compile.dart",
+        "lib/product/platform/product_platform_composition.dart",
         "lib/product/runtime/product_runtime.dart",
         "lib/product/security/product_security.dart"
       ]

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -71,6 +71,15 @@ endif()
 
 set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
 set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(AMD64|amd64|x86_64)$")
+  set(RUNTIME_ARCHITECTURE "x86_64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+  set(RUNTIME_ARCHITECTURE "arm64")
+else()
+  message(FATAL_ERROR "Unsupported Windows runtime architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+set(INSTALL_RUNTIME_DIR
+  "${CMAKE_INSTALL_PREFIX}/runtimes/windows/${RUNTIME_ARCHITECTURE}")
 
 install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)
@@ -81,7 +90,7 @@ install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}
 install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)
 
-# libclash.so
+# Desktop runtime artifacts use the ProductInstallLayout contract.
 set(CLASH_DIR "../libclash/windows")
 
 # if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
@@ -90,11 +99,11 @@ set(CLASH_DIR "../libclash/windows")
 #   set(CLASH_DIR "../libclash/windows/x86")
 # endif()
 
-install(PROGRAMS "${CLASH_DIR}/FlClashCore.exe" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-  COMPONENT Runtime)
+install(PROGRAMS "${CLASH_DIR}/FlClashCore.exe" DESTINATION "${INSTALL_RUNTIME_DIR}"
+  RENAME "mihomo.exe" COMPONENT Runtime)
 
-install(PROGRAMS "${CLASH_DIR}/FlClashHelperService.exe" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-  COMPONENT Runtime)
+install(PROGRAMS "${CLASH_DIR}/FlClashHelperService.exe" DESTINATION "${INSTALL_RUNTIME_DIR}"
+  RENAME "app.flclashm.client.helper.exe" COMPONENT Runtime)
 
 install(FILES "EnableLoopback.exe" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)

--- a/windows/packaging/exe/inno_setup.iss
+++ b/windows/packaging/exe/inno_setup.iss
@@ -41,7 +41,7 @@ var
   i: Integer;
   ResultCode: Integer;
 begin
-  Processes := ['FlClashM.exe', 'FlClashCore.exe', 'FlClashHelperService.exe'];
+  Processes := ['FlClashM.exe'];
 
   // First try graceful shutdown
   for i := 0 to GetArrayLength(Processes)-1 do
@@ -91,17 +91,11 @@ begin
 end;
 
 function InitializeSetup(): Boolean;
-var
-  ResultCode: Integer;
 begin
   // Check if app is already installed
   IsUpgrade := IsAppInstalled();
   if IsUpgrade then
     PreviousVersion := GetInstalledVersion();
-  
-  // Stop service if running
-  Exec('sc.exe', 'stop "FlClashHelperService"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-  Sleep(1000);
   
   // Kill all processes
   KillProcesses;
@@ -148,49 +142,21 @@ begin
     Result := Result + MemoTasksInfo + NewLine;
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
-var
-  ResultCode: Integer;
-begin
-  if CurStep = ssPostInstall then
-  begin
-    // Refresh icon cache/associations
-    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
-    Sleep(500);
-    // Ensure helper service is started after install/upgrade, independent of app
-    try
-      Exec('sc.exe', 'start "FlClashHelperService"', '', SW_HIDE, ewNoWait, ResultCode);
-    except
-    end;
-  end;
-end;
-
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
-var
-  ResultCode: Integer;
 begin
   case CurUninstallStep of
     usUninstall:
     begin
-      // Stop service first
-      Exec('sc.exe', 'stop "FlClashHelperService"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      Sleep(1000);
-      
-      // Kill all processes
       KillProcesses;
-      
-      // Delete service
-      Exec('sc.exe', 'delete "FlClashHelperService"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      Sleep(500);
     end;
-    
+
     usPostUninstall:
     begin
-      if DirExists(ExpandConstant('{userappdata}\com.follow\clashx')) then
+      if DirExists(ExpandConstant('{userappdata}\app.flclashm.client')) then
       begin
         if MsgBox('Удалить пользовательские данные программы?', mbConfirmation, MB_YESNO) = IDYES then
         begin
-          DelTree(ExpandConstant('{userappdata}\com.follow\clashx'), True, True, True);
+          DelTree(ExpandConstant('{userappdata}\app.flclashm.client'), True, True, True);
         end;
       end;
     end;

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -1,5 +1,5 @@
 script_template: inno_setup.iss
-app_id: 728B3532-C74B-4870-9068-BE70FE12A3E6
+app_id: app.flclashm.client
 app_name: FlClashM
 publisher: pluralplay
 publisher_url: https://github.com/makriq-org/FlClashM


### PR DESCRIPTION
## Зачем
Нужно отделить Android-склейку от будущих desktop-платформ, сохранив текущие Android-контракты.

## Что сделано
- добавлена единая композиция Android, Linux, Windows и macOS
- добавлены desktop-заглушки TUN, helper и установки обновлений с явной ошибкой capability
- зафиксированы desktop ID и общий layout runtime-артефактов
- добавлены unit-тесты выбора композиции, desktop-изоляции и Android-политик

## Как проверено
- flutter test --no-pub test/product
- flutter analyze --no-pub для изменённых product-исходников
- dart tool/check_product_boundaries.dart
- dart tool/check_base_drift.dart
- ручная проверка не выполнялась

## Влияние на пользователя
CHANGELOG не требуется · BREAKING нет
