### PR TITLE
fix: устранена гонка проверки VPN-уведомления

### DIFF
--- a/android/app/src/androidTest/kotlin/com/follow/clashx/AndroidRuntimeE2eTest.kt
+++ b/android/app/src/androidTest/kotlin/com/follow/clashx/AndroidRuntimeE2eTest.kt
@@ -161,7 +161,7 @@ class AndroidRuntimeE2eTest {
         Service.stopService()
         await("VPN stop") { Service.fetchServiceState()?.state == "stopped" }
         await("VPN transport cleanup") { !hasVpnTransport() }
-        assertNull("foreground notification was not removed", foregroundNotification())
+        await("foreground notification cleanup") { foregroundNotification() == null }
         assertTrue("VPN active marker was not cleared", !SavedParams.isVpnActive())
         assertNotEquals("remote process unexpectedly disappeared on normal stop", 0, remotePid())
     }


### PR DESCRIPTION
## Зачем
Android E2E проверял удаление foreground-уведомления сразу после перехода VPN в состояние stopped. Обработка ACTION_STOP и удаление уведомления асинхронны, поэтому тест нестабильно падал при корректной остановке VPN.

## Что сделано
- мгновенная проверка уведомления заменена ожиданием через существующий await
- сохранён общий таймаут и диагностическое имя этапа

## Как проверено
- dart tool/check_product_boundaries.dart
- dart tool/check_base_drift.dart
- git diff --check
- полный Android E2E запускается в CI

## Влияние на пользователя
CHANGELOG не требуется · нет BREAKING