### PR TITLE
chore: описаны desktop-ветки и исключены файлы Claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ migrate_working_dir/
 # is commented out by default.
 .vscode/
 
+# Local Claude Code configuration and generated worktrees
+/.claude/
+
 # Flutter/Dart/Pub related
 **/doc/api/
 **/ios/Flutter/.last_build_id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,15 @@ RawProfile → ProfileCompiler → SecurityPolicy → RuntimePlan → EngineMana
 
 Пример: `feat/olcrtc-auto-activation`. Прямой push в `main` запрещён — только через PR.
 
+### Desktop-направление
+
+- `feat/cross-platform` — постоянная интеграционная ветка desktop-направления. Пока
+  направление активно, ветку не удалять, даже если её текущая вершина уже входит в
+  `main`.
+- Этапы работы ответвляются от `feat/cross-platform`, а их PR направляются обратно в
+  неё. После слияния удаляется только ветка этапа.
+- Первый этап — `feat/platform-composition`.
+
 ## Коммиты
 
 Формат заголовка: **`тип: описание`**


### PR DESCRIPTION
## Зачем
Интеграционная desktop-ветка должна сохраняться между этапами, а локальные файлы Claude не должны попадать в репозиторий.

## Что сделано
- описан контракт веток desktop-направления в AGENTS.md
- каталог .claude добавлен в .gitignore

## Как проверено
- git diff --check

## Влияние на пользователя
CHANGELOG не требуется · нет BREAKING